### PR TITLE
Render the proper host and port for the connection string

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -23,6 +23,7 @@ using Hangfire.Annotations;
 using Hangfire.Logging;
 using StackExchange.Redis;
 using System.Text;
+using System.Net;
 
 namespace Hangfire.Redis
 {
@@ -56,7 +57,8 @@ namespace Hangfire.Redis
 
 			_connectionMultiplexer = ConnectionMultiplexer.Connect(connectionString);
 			_invisibilityTimeout = invisibilityTimeout;
-			ConnectionString = _connectionMultiplexer.GetEndPoints(true)[0].ToString();
+			var endpoint = (DnsEndPoint)_connectionMultiplexer.GetEndPoints()[0];
+			ConnectionString = string.Format("{0}:{1}", endpoint.Host, endpoint.Port);
 			Db = db;
 
 		}


### PR DESCRIPTION
When `EndPoint.ToString()` is called it would render a string that did not match the output that was expected:

```csharp
Unspecified/devredis01:6379
```
 Instead this change adjusts it so that it renders the host and port number without the `AddressFamily` property (which was always "Unspecified"):

```csharp
devredis01:6379
```

This was mostly noticed on the Hangfire dashboard, which would show the connection in the footer as:

```csharp
redis://Unspecified/devredis01:6379/1
```

It will now render properly:

```csharp
redis://devredis01:6379/1
```

This was not breaking anything in the library itself, just in the visual representation which is retrieved through the `ToString()` method in the `RedisStorage` class.