### PR TITLE
FetchNextJob performance tweaks.

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -28,14 +28,16 @@ namespace Hangfire.Redis
 {
     internal class RedisConnection : JobStorageConnection
     {
-        private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(1);
         readonly ISubscriber _subscriber;
-        string _jobStorageIdentity;
+        readonly string _jobStorageIdentity;
+        readonly TimeSpan _fetchTimeout;
         readonly ManualResetEvent mre;
-        public RedisConnection(IDatabase redis, ISubscriber subscriber, string jobStorageIdentity)
+        public RedisConnection(IDatabase redis, ISubscriber subscriber, string jobStorageIdentity, TimeSpan fetchTimeout)
         {
-            _subscriber = subscriber;
+            _subscriber = subscriber;            
             _jobStorageIdentity = jobStorageIdentity;
+            _fetchTimeout = fetchTimeout;
+
             Redis = redis;
             mre = new ManualResetEvent(false);
 
@@ -156,7 +158,7 @@ namespace Hangfire.Redis
 
                 if (jobId == null)
                 {
-                    WaitHandle.WaitAny(new[] { mre, cancellationToken.WaitHandle }, TimeSpan.FromMinutes(3));
+                    WaitHandle.WaitAny(new[] { mre, cancellationToken.WaitHandle }, _fetchTimeout);
                     mre.Reset();
                 }
             } while (jobId == null);

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -36,6 +36,7 @@ namespace Hangfire.Redis
         private readonly string identity;
         private readonly ConnectionMultiplexer _connectionMultiplexer;
         private TimeSpan _invisibilityTimeout;
+        private TimeSpan _fetchTimeout;
 
         public RedisStorage()
             : this("localhost:6379")
@@ -49,6 +50,8 @@ namespace Hangfire.Redis
 
             _connectionMultiplexer = ConnectionMultiplexer.Connect(connectionString);
             _invisibilityTimeout = options.InvisibilityTimeout;
+            _fetchTimeout = options.FetchTimeout;
+
             var endpoint = _connectionMultiplexer.GetEndPoints()[0];
             if (endpoint is IPEndPoint)
             {
@@ -87,7 +90,7 @@ namespace Hangfire.Redis
 
         public override IStorageConnection GetConnection()
         {
-            return new RedisConnection(_connectionMultiplexer.GetDatabase(Db), _connectionMultiplexer.GetSubscriber(), identity);
+            return new RedisConnection(_connectionMultiplexer.GetDatabase(Db), _connectionMultiplexer.GetSubscriber(), identity, _fetchTimeout);
         }
 
         public override IEnumerable<IServerComponent> GetComponents()

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -49,6 +49,7 @@ namespace Hangfire.Redis
             if (options == null) options = new RedisStorageOptions();
 
             _connectionMultiplexer = ConnectionMultiplexer.Connect(connectionString);
+            _connectionMultiplexer.PreserveAsyncOrder = false;
             _invisibilityTimeout = options.InvisibilityTimeout;
             _fetchTimeout = options.FetchTimeout;
 

--- a/Hangfire.Redis.StackExchange/RedisStorageOptions.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorageOptions.cs
@@ -23,10 +23,11 @@ namespace Hangfire.Redis
     public class RedisStorageOptions 
     {
         public const string DefaultPrefix = "hangfire:";
-
+        
         public RedisStorageOptions() 
         {
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
+            FetchTimeout = TimeSpan.FromMinutes(3);
             Db = 0;
             Prefix = DefaultPrefix;
             SucceededListSize = 499;
@@ -34,6 +35,7 @@ namespace Hangfire.Redis
         }
 
         public TimeSpan InvisibilityTimeout { get; set; }
+        public TimeSpan FetchTimeout { get; set; }
         public string Prefix { get; set; }
         public int Db { get; set; }
 

--- a/Hangfire.Redis.Tests/RedisConnectionFacts.cs
+++ b/Hangfire.Redis.Tests/RedisConnectionFacts.cs
@@ -188,7 +188,7 @@ namespace Hangfire.Redis.Tests
         private void UseConnections(Action<IDatabase, RedisConnection> action)
         {
 			var redis = RedisUtils.CreateClient();
-            using (var connection = new RedisConnection(redis, RedisUtils.CreateSubscriber(), Guid.NewGuid().ToString()))
+            using (var connection = new RedisConnection(redis, RedisUtils.CreateSubscriber(), Guid.NewGuid().ToString(), new RedisStorageOptions().FetchTimeout))
             {
 				action(redis, connection);
             }
@@ -196,7 +196,7 @@ namespace Hangfire.Redis.Tests
 
         private void UseConnection(Action<RedisConnection> action)
         {
-            using (var connection = new RedisConnection(RedisUtils.CreateClient(), RedisUtils.CreateSubscriber(), Guid.NewGuid().ToString()))
+            using (var connection = new RedisConnection(RedisUtils.CreateClient(), RedisUtils.CreateSubscriber(), Guid.NewGuid().ToString(), new RedisStorageOptions().FetchTimeout))
             {
 				action(connection);
             }


### PR DESCRIPTION
Implemented configurable timeout (instead of hardcoded 3 min) when scanning queues for new jobs. In some cases (e.g. troubles with Redis Pub/Sub) long timeouts can lead to downtime.

Disabled preserving Pub/Sub events order in Redis multiplexer. This could improve Pub/Sub events processing performance. 