### PR TITLE
Nuspec/Dependency broken - now fixed

### DIFF
--- a/Hangfire.Redis.StackExchange/HangFire.Redis.StackExchange.nuspec
+++ b/Hangfire.Redis.StackExchange/HangFire.Redis.StackExchange.nuspec
@@ -22,12 +22,12 @@ It also supports Batches (Pro Feature)</summary>
         <tags>Hangfire Redis</tags>
         <dependencies>
             <group targetFramework=".NETFramework4.5.1">
-                <dependency id="HangFire.Core" version="1.6.5" />
+                <dependency id="Hangfire.Core" version="1.6.5" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="StackExchange.Redis" version="1.1.606" />
             </group>
             <group targetFramework=".NETStandard1.6">
-                <dependency id="HangFire.Core" version="1.6.5" />
+                <dependency id="Hangfire.Core" version="1.6.5" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="StackExchange.Redis" version="1.1.606" />
             </group>


### PR DESCRIPTION
Dear Marco,

This little Case-Sensitive error causes build errors in involved projects because it cannot resolve the dependencies correctly. This commit will fix it.