### PR TITLE
README: Improve badges

### DIFF
--- a/Hangfire.Redis.StackExchange.StrongName/Hangfire.Redis.StackExchange.StrongName.csproj
+++ b/Hangfire.Redis.StackExchange.StrongName/Hangfire.Redis.StackExchange.StrongName.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;net46;netstandard1.5</TargetFrameworks>
     <PackageId>Hangfire.Redis.StackExchange.StrongName</PackageId>
-    <Version>1.7.0-beta2</Version>
+    <Version>1.7.0</Version>
     <Authors>Marco Casamento</Authors>
     <owners>marcocasamento</owners>
     <!--
@@ -21,27 +21,30 @@
       Hangfire Redis storage use Redis to persists Job information, through Redis.StackExchange library.
       It also supports Batches (Pro Feature)
     </Summary>
-    <PackageReleaseNotes>1.7.0-beta
-    - Redis Cluster support (#42 thanks to gzpbx)
-1.6.7
-    - Added support for Redis DB in the ConnectionString (#26 thanks to zivillian)
-    - Added constructor to RedisStorage that accepts a ConnectionMultiplexer instance (#23 thanks to sjwoodard)
-    - Lowered dependencies for net45 framework and aligned to Hangfire.Core (#21 thanks to zlangner)
-    - Fixed dependency casing of Hangfire.Core (#33 thanks to Poly3k)
-    - Fix Dispose of RedisSupscription (#32 thanks to WebApelsin)
-    - Fixed random failure of test NestLockDisposePreservesRoot
-1.6.6
-    - Configurable timeout for FetchNextJob (thanks to WebApelsin)
-1.6.5
-    - .Net Core Support (thanks to Stefan Polyanszky)
-    - Aligned dependency to Hangfire.Core</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      1.7.0
+      - Redis Cluster support (#42 thanks to gzpbx)
+      - Update to VS2017 (#48 thanks to ryanelian)
+      1.6.7
+      - Added support for Redis DB in the ConnectionString (#26 thanks to zivillian)
+      - Added constructor to RedisStorage that accepts a ConnectionMultiplexer instance (#23 thanks to sjwoodard)
+      - Lowered dependencies for net45 framework and aligned to Hangfire.Core (#21 thanks to zlangner)
+      - Fixed dependency casing of Hangfire.Core (#33 thanks to Poly3k)
+      - Fix Dispose of RedisSupscription (#32 thanks to WebApelsin)
+      - Fixed random failure of test NestLockDisposePreservesRoot
+      1.6.6
+      - Configurable timeout for FetchNextJob (thanks to WebApelsin)
+      1.6.5
+      - .Net Core Support (thanks to Stefan Polyanszky)
+      - Aligned dependency to Hangfire.Core
+    </PackageReleaseNotes>
     <PackageTags>Hangfire Redis</PackageTags>
     <RepositoryUrl>https://github.com/marcoCasamento/Hangfire.Redis.StackExchange</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseUrl>http://www.gnu.org/licenses/lgpl-3.0.html</PackageLicenseUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>Hangfire_Redis_StackExchange.snk</AssemblyOriginatorKeyFile>
+    <!--<SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>Hangfire_Redis_StackExchange.snk</AssemblyOriginatorKeyFile>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
+++ b/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
@@ -36,7 +36,8 @@
       - Configurable timeout for FetchNextJob (thanks to WebApelsin)
       1.6.5
       - .Net Core Support (thanks to Stefan Polyanszky)
-      - Aligned dependency to Hangfire.Core</PackageReleaseNotes>
+      - Aligned dependency to Hangfire.Core
+    </PackageReleaseNotes>
     <PackageTags>Hangfire Redis</PackageTags>
     <RepositoryUrl>https://github.com/marcoCasamento/Hangfire.Redis.StackExchange</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Hangfire.Redis.StackExchange
 
-![Build Status](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva/branch/master?svg=true)
-[![Nuget Badge](https://buildstats.info/nuget/Hangfire.Redis.StackExchange)](https://www.nuget.org/packages/Hangfire.Redis.StackExchange/)
+> HangFire Redis storage based on [HangFire.Redis](https://github.com/HangfireIO/Hangfire.Redis/) but using lovely [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) client.
 
-HangFire Redis storage based on [HangFire.Redis](https://github.com/HangfireIO/Hangfire.Redis/) but using lovely [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) client.
+[![Build Status](https://img.shields.io/appveyor/ci/marcoCasamento/Hangfire-Redis-StackExchange.svg)](https://ci.appveyor.com/project/marcoCasamento/Hangfire-Redis-StackExchange)
+
+| Package Name                                  | NuGet.org                                                                                                                                                             |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Hangfire.Redis.StackExchange`                | [![Nuget Badge](https://img.shields.io/nuget/v/Hangfire.Redis.StackExchange.svg)](https://www.nuget.org/packages/Hangfire.Redis.StackExchange/)                       |
+| `Hangfire.Redis.StackExchange.StrongName`     | [![Nuget Badge](https://img.shields.io/nuget/v/Hangfire.Redis.StackExchange.StrongName.svg)](https://www.nuget.org/packages/Hangfire.Redis.StackExchange.StrongName/) |
 
 #### Highlights
 - Support for Hangfire Batches ([feature of Hangfire Pro](http://hangfire.io/blog/2015/04/17/hangfire-pro-1.2.0-released.html))
 - Efficient use of Redis resources thanks to ConnectionMultiplexer
 - Support for Redis Prefix, allow multiple Hangfire Instances against a single Redis DB
 - Allow customization of Succeeded and Failed lists size
+
+> Despite the name, `Hangfire.Redis.StackExchange.StrongName` is **not signed** because `Hangfire.Core` is not yet signed.
 
 ## Tutorial: Hangfire on Redis on ASP.NET Core MVC
 
@@ -45,7 +51,7 @@ public class Startup
 }
 ```
 
-> Warning: If you are using `Microsoft.Extensions.Caching.Redis` package, you will need to use `Hangfire.Redis.StackExchange.StrongName` instead, because the former package requires `StackExchange.Redis.StrongName` instead of `StackExchange.Redis`!!! 
+> **Attention:** If you are using `Microsoft.Extensions.Caching.Redis` package, you will need to use `Hangfire.Redis.StackExchange.StrongName` instead, because the former package requires `StackExchange.Redis.StrongName` instead of `StackExchange.Redis`!
 
 ### Configurations
 


### PR DESCRIPTION
- Fixed broken AppVeyor badge
- Added `Hangfire.Redis.StackExchange.StrongName` package badge.

Solves #49 

----

I'd figure you're busy (a week has passed, and I kind of need the package uploaded), therefore I've taken the liberty of uploading the `StrongName` package, as per plan 2.

I have made you (mCasamento) a fellow owner at NuGet.org, so you can take control of the package.