### PR TITLE
Fix job state order

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
+++ b/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
@@ -409,6 +409,9 @@ namespace Hangfire.Redis
 
                 var historyList = redis.ListRange(RedisStorage.Prefix + string.Format("job:{0}:history", jobId))
 					.Select(x=> (string)x).ToList();
+                
+                // history is in wrong order, fix this
+                historyList.Reverse();
 
                 var history = historyList
                     .Select(JobHelper.FromJson<Dictionary<string, string>>)


### PR DESCRIPTION
Job timeline follows from the bottom (fake 'Created' state) to top (current job state), but it appears to be wrong for this storage provider.