### PR TITLE
Add expired jobs watcher to cleanup succeeded/deleted lists

### DIFF
--- a/Hangfire.Redis.StackExchange.StrongName/Hangfire.Redis.StackExchange.StrongName.csproj
+++ b/Hangfire.Redis.StackExchange.StrongName/Hangfire.Redis.StackExchange.StrongName.csproj
@@ -51,6 +51,7 @@
     <Compile Include="..\Hangfire.Redis.StackExchange\DeletedStateHandler.cs" Link="DeletedStateHandler.cs" />
     <Compile Include="..\Hangfire.Redis.StackExchange\FailedStateHandler.cs" Link="FailedStateHandler.cs" />
     <Compile Include="..\Hangfire.Redis.StackExchange\FetchedJobsWatcher.cs" Link="FetchedJobsWatcher.cs" />
+    <Compile Include="..\Hangfire.Redis.StackExchange\ExpiredJobsWatcher.cs" Link="ExpiredJobsWatcher.cs" />
     <Compile Include="..\Hangfire.Redis.StackExchange\FetchedJobsWatcherOptions.cs" Link="FetchedJobsWatcherOptions.cs" />
     <Compile Include="..\Hangfire.Redis.StackExchange\HangFireRedisException.cs" Link="HangFireRedisException.cs" />
     <Compile Include="..\Hangfire.Redis.StackExchange\ProcessingStateHandler.cs" Link="ProcessingStateHandler.cs" />

--- a/Hangfire.Redis.StackExchange/ExpiredJobsWatcher.cs
+++ b/Hangfire.Redis.StackExchange/ExpiredJobsWatcher.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hangfire.Logging;
+using Hangfire.Server;
+using StackExchange.Redis;
+
+// ReSharper disable once CheckNamespace
+namespace Hangfire.Redis
+{
+#pragma warning disable 618
+    internal class ExpiredJobsWatcher : IServerComponent
+#pragma warning restore 618
+    {
+        private static readonly ILog Logger = LogProvider.For<ExpiredJobsWatcher>();
+        
+        private readonly RedisStorage _storage;
+        private readonly TimeSpan _checkInterval;
+
+        private static readonly string[] ProcessedKeys =
+        {
+            "succeeded",
+            "deleted"
+        };
+        
+        public ExpiredJobsWatcher(RedisStorage storage, TimeSpan checkInterval)
+        {
+            if (storage == null) 
+                throw new ArgumentNullException("storage");
+            if (checkInterval.Ticks <= 0)
+                throw new ArgumentOutOfRangeException("checkInterval", "Check interval should be positive.");
+            
+            _storage = storage;
+            _checkInterval = checkInterval;
+        }
+
+        public override string ToString()
+        {
+            return GetType().ToString();
+        }
+
+        void IServerComponent.Execute(CancellationToken cancellationToken)
+        {
+            using (var connection = (RedisConnection)_storage.GetConnection())
+            {
+                var redis = connection.Redis;
+                
+                foreach (var key in ProcessedKeys)
+                {
+                    var count = redis.ListLength(RedisStorage.Prefix + key);
+                    if (count == 0) continue;
+
+                    Logger.InfoFormat("Removing expired records from the '{0}' list...", key);
+                    
+                    const int batchSize = 100;
+                    var keysToRemove = new List<string>();
+                    
+                    for (var last = count - 1; last >= 0; last -= batchSize)
+                    {
+                        var first = Math.Max(0, last - batchSize + 1);
+                        
+                        var jobIds = redis.ListRange(RedisStorage.Prefix + key, first, last).ToStringArray();
+                        if (jobIds.Length == 0) continue;
+                        
+                        var pipeline = redis.CreateBatch();
+                        var tasks = new Task[jobIds.Length];
+
+                        for (var i = 0; i < jobIds.Length; i++)
+                        {
+                            tasks[i] = pipeline.KeyExistsAsync(
+                                string.Format("{0}job:{1}", RedisStorage.Prefix, jobIds[i]));
+                        }
+                        
+                        pipeline.Execute();
+                        Task.WaitAll(tasks);
+
+                        keysToRemove.AddRange(jobIds.Where((t, i) => !((Task<bool>)tasks[i]).Result));
+                    }
+                    
+                    if (keysToRemove.Count == 0) continue;
+
+                    Logger.InfoFormat("Removing {0} expired jobs from '{1}' list...", keysToRemove.Count, key);
+
+                    using (var transaction = connection.CreateWriteTransaction())
+                    {
+                        foreach (var jobId in keysToRemove)
+                        {
+                            transaction.RemoveFromList(key, jobId);
+                        }
+                        
+                        transaction.Commit();
+                    }
+                }
+            }
+
+            cancellationToken.WaitHandle.WaitOne(_checkInterval);
+        }
+    }
+}

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -39,6 +39,7 @@ namespace Hangfire.Redis
         private readonly RedisSubscription _subscription;
         private TimeSpan _invisibilityTimeout;
         private TimeSpan _fetchTimeout;
+        private TimeSpan _expiryCheckInterval;
 
         public RedisStorage()
             : this("localhost:6379")
@@ -80,6 +81,7 @@ namespace Hangfire.Redis
         {
             _invisibilityTimeout = options.InvisibilityTimeout;
             _fetchTimeout = options.FetchTimeout;
+            _expiryCheckInterval = options.ExpiryCheckInterval;
             ConnectionString = connectionMultiplexer.Configuration;
 
             Db = options.Db;
@@ -114,6 +116,7 @@ namespace Hangfire.Redis
         public override IEnumerable<IServerComponent> GetComponents()
         {
             yield return new FetchedJobsWatcher(this, _invisibilityTimeout);
+            yield return new ExpiredJobsWatcher(this, _expiryCheckInterval);
             yield return _subscription;
         }
 

--- a/Hangfire.Redis.StackExchange/RedisStorageOptions.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorageOptions.cs
@@ -28,6 +28,7 @@ namespace Hangfire.Redis
         {
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
             FetchTimeout = TimeSpan.FromMinutes(3);
+            ExpiryCheckInterval = TimeSpan.FromHours(1);
             Db = 0;
             Prefix = DefaultPrefix;
             SucceededListSize = 499;
@@ -36,6 +37,7 @@ namespace Hangfire.Redis
 
         public TimeSpan InvisibilityTimeout { get; set; }
         public TimeSpan FetchTimeout { get; set; }
+        public TimeSpan ExpiryCheckInterval { get; set; }
         public string Prefix { get; set; }
         public int Db { get; set; }
 

--- a/Hangfire.Redis.Tests/ExpiredJobsWatcherFacts.cs
+++ b/Hangfire.Redis.Tests/ExpiredJobsWatcherFacts.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading;
+using Hangfire.Common;
+using Hangfire.Server;
+using Xunit;
+
+namespace Hangfire.Redis.Tests
+{
+    [CleanRedis]
+    public class ExpiredJobsWatcherFacts
+    {
+        private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(1);
+
+        private readonly RedisStorage _storage;
+		private readonly CancellationTokenSource _cts;
+
+        public ExpiredJobsWatcherFacts()
+        {
+            var options = new RedisStorageOptions() { Db = RedisUtils.GetDb() };
+            _storage = new RedisStorage(RedisUtils.GetHostAndPort(), options);
+			_cts = new CancellationTokenSource();
+			_cts.Cancel();
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenStorageIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new ExpiredJobsWatcher(null, CheckInterval));
+
+            Assert.Equal("storage", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenCheckIntervalIsZero()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new ExpiredJobsWatcher(_storage, TimeSpan.Zero));
+
+            Assert.Equal("checkInterval", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenCheckIntervalIsNegative()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new ExpiredJobsWatcher(_storage, TimeSpan.FromSeconds(-1)));
+
+            Assert.Equal("checkInterval", exception.ParamName);
+        }
+
+        [Fact, CleanRedis]
+        public void Execute_DeletesNonExistingJobs()
+        {
+            var redis = RedisUtils.CreateClient();
+            // Arrange
+            redis.ListRightPush("{hangfire}:succeded", "my-job");
+            redis.ListRightPush("{hangfire}:deleted", "other-job");
+
+            var watcher = CreateWatcher();
+            
+            // Act
+            watcher.Execute(_cts.Token);
+            
+            // Assert
+            Assert.Equal(0, redis.ListLength("{hangfire}:succeeded"));
+            Assert.Equal(0, redis.ListLength("{hangfire}:deleted"));
+        }
+        
+        [Fact, CleanRedis]
+        public void Execute_DoesNotDeleteExistingJobs()
+        {
+            var redis = RedisUtils.CreateClient();
+            // Arrange
+            redis.ListRightPush("{hangfire}:succeeded", "my-job");
+            redis.HashSet("{hangfire}:job:my-job", "Fetched",
+                JobHelper.SerializeDateTime(DateTime.UtcNow.AddDays(-1)));
+            
+            redis.ListRightPush("{hangfire}:deleted", "other-job");
+            redis.HashSet("{hangfire}:job:other-job", "Fetched",
+                JobHelper.SerializeDateTime(DateTime.UtcNow.AddDays(-1)));
+
+            var watcher = CreateWatcher();
+            
+            // Act
+            watcher.Execute(_cts.Token);
+            
+            // Assert
+            Assert.Equal(1, redis.ListLength("{hangfire}:succeeded"));
+            Assert.Equal(1, redis.ListLength("{hangfire}:deleted"));
+        }
+        
+        private IServerComponent CreateWatcher()
+        {
+            return new ExpiredJobsWatcher(_storage, CheckInterval);
+        }
+    }
+}


### PR DESCRIPTION
This would allow to not limit succeeded/deleted list sizes, but still to keep the storage clean.