### PR TITLE
Refactor code

### DIFF
--- a/Hangfire.Redis.StackExchange.StrongName/Hangfire.Redis.StackExchange.StrongName.csproj
+++ b/Hangfire.Redis.StackExchange.StrongName/Hangfire.Redis.StackExchange.StrongName.csproj
@@ -72,7 +72,7 @@
   <ItemGroup>
     <PackageReference Include="HangFire.Core" Version="1.6.12" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.1" />
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
   </ItemGroup>
 
 </Project>

--- a/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
+++ b/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <PackageReference Include="HangFire.Core" Version="1.6.12" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="1.2.1" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
   </ItemGroup>
 
 </Project>

--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -80,10 +80,9 @@ namespace Hangfire.Redis
 
             foreach (var queue in context.Queues)
             {
-                var queue1 = queue;
                 transaction.ListRightPushAsync(
                     _storage.GetRedisKey($"server:{serverId}:queues"),
-                    queue1);
+                    queue);
             }
 
             transaction.Execute();
@@ -384,9 +383,8 @@ namespace Hangfire.Redis
             
             foreach (var serverName in serverNames)
             {
-                var name = serverName;
-                var srv = Redis.HashGet(_storage.GetRedisKey($"server:{name}"), new RedisValue[] { "StartedAt", "Heartbeat" });
-                heartbeats.Add(name,
+                var srv = Redis.HashGet(_storage.GetRedisKey($"server:{serverName}"), new RedisValue[] { "StartedAt", "Heartbeat" });
+                heartbeats.Add(serverName,
                                 new Tuple<DateTime, DateTime?>(
                                 JobHelper.DeserializeDateTime(srv[0]),
                                 JobHelper.DeserializeNullableDateTime(srv[1])));

--- a/Hangfire.Redis.StackExchange/RedisDatabaseExtensions.cs
+++ b/Hangfire.Redis.StackExchange/RedisDatabaseExtensions.cs
@@ -36,6 +36,14 @@ namespace Hangfire.Redis
 			}
 			return hashEntry;
 		}
+
+        public static RedisValue[] ToRedisValues(this IEnumerable<string> values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+
+            return values.Select(x => (RedisValue)x).ToArray();
+        }
 		
 		//public static Dictionary<string, string> ToStringDictionary(this HashEntry[] entries)
 		//{
@@ -45,11 +53,6 @@ namespace Hangfire.Redis
 		//	return dictionary;
 		//}
 		
-		public static bool ContainsKey(this HashEntry[] hashEntries, RedisValue key)
-		{
-			return hashEntries.Any(x=> x.Name == key);
-		}
-
         public static Dictionary<string, string> GetValuesMap(this IDatabase redis, string[] keys)
 		{
 			var redisKeyArr = keys.Select(x => (RedisKey)x).ToArray();

--- a/Hangfire.Redis.StackExchange/RedisFetchedJob.cs
+++ b/Hangfire.Redis.StackExchange/RedisFetchedJob.cs
@@ -17,29 +17,38 @@
 using System;
 using Hangfire.Storage;
 using StackExchange.Redis;
+using Hangfire.Annotations;
+
 namespace Hangfire.Redis
 {
     internal class RedisFetchedJob : IFetchedJob
     {
+        private readonly RedisStorage _storage;
 		private readonly IDatabase _redis;
         private bool _disposed;
         private bool _removedFromQueue;
         private bool _requeued;
 
-        public RedisFetchedJob(IDatabase redis, string jobId, string queue)
+        public RedisFetchedJob(
+            [NotNull] RedisStorage storage, 
+            [NotNull] IDatabase redis,
+            [NotNull] string jobId, 
+            [NotNull] string queue)
         {
-            if (redis == null) throw new ArgumentNullException("redis");
-            if (jobId == null) throw new ArgumentNullException("jobId");
-            if (queue == null) throw new ArgumentNullException("queue");
+            if (storage == null) throw new ArgumentNullException(nameof(storage));
+            if (redis == null) throw new ArgumentNullException(nameof(redis));
+            if (jobId == null) throw new ArgumentNullException(nameof(jobId));
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
 
+            _storage = storage;
             _redis = redis;
 
             JobId = jobId;
             Queue = queue;
         }
 
-        public string JobId { get; private set; }
-        public string Queue { get; private set; }
+        public string JobId { get; }
+        public string Queue { get; }
 
         public void RemoveFromQueue()
         {
@@ -54,9 +63,8 @@ namespace Hangfire.Redis
         public void Requeue()
         {
 			var transaction = _redis.CreateTransaction();
-            transaction.ListRightPushAsync(
-                RedisStorage.Prefix + string.Format("queue:{0}", Queue),
-                JobId);
+
+            transaction.ListRightPushAsync(_storage.GetRedisKey($"queue:{Queue}"), JobId);
 
             RemoveFromFetchedList(transaction);
 
@@ -79,17 +87,9 @@ namespace Hangfire.Redis
 
         private void RemoveFromFetchedList(ITransaction transaction)
         {
-            transaction.ListRemoveAsync(
-                        RedisStorage.Prefix + string.Format("queue:{0}:dequeued", Queue),
-                        JobId,
-                        -1);
-
-            transaction.HashDeleteAsync(
-                RedisStorage.Prefix + string.Format("job:{0}", JobId),
-                "Fetched");
-            transaction.HashDeleteAsync(
-                RedisStorage.Prefix + string.Format("job:{0}", JobId),
-                "Checked");
+            transaction.ListRemoveAsync(_storage.GetRedisKey($"queue:{Queue}:dequeued"), JobId, -1);
+            transaction.HashDeleteAsync(_storage.GetRedisKey($"job:{JobId}"), "Fetched");
+            transaction.HashDeleteAsync(_storage.GetRedisKey($"job:{JobId}"), "Checked");
         }
     }
 }

--- a/Hangfire.Redis.StackExchange/RedisFetchedJob.cs
+++ b/Hangfire.Redis.StackExchange/RedisFetchedJob.cs
@@ -65,7 +65,7 @@ namespace Hangfire.Redis
 			var transaction = _redis.CreateTransaction();
 
             transaction.ListRightPushAsync(_storage.GetRedisKey($"queue:{Queue}"), JobId);
-
+            
             RemoveFromFetchedList(transaction);
 
             transaction.Execute();
@@ -88,8 +88,7 @@ namespace Hangfire.Redis
         private void RemoveFromFetchedList(ITransaction transaction)
         {
             transaction.ListRemoveAsync(_storage.GetRedisKey($"queue:{Queue}:dequeued"), JobId, -1);
-            transaction.HashDeleteAsync(_storage.GetRedisKey($"job:{JobId}"), "Fetched");
-            transaction.HashDeleteAsync(_storage.GetRedisKey($"job:{JobId}"), "Checked");
+            transaction.HashDeleteAsync(_storage.GetRedisKey($"job:{JobId}"), new RedisValue[] { "Fetched", "Checked" });
         }
     }
 }

--- a/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
+++ b/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
@@ -191,13 +191,12 @@ namespace Hangfire.Redis
 
                 foreach (var serverName in serverNames)
                 {
-                    var name = serverName;
-                    servers.Add(name,
-                        redis.HashGet(_storage.GetRedisKey($"server:{name}"), new RedisValue[] { "WorkerCount", "StartedAt", "Heartbeat" })
+                    servers.Add(serverName,
+                        redis.HashGet(_storage.GetRedisKey($"server:{serverName}"), new RedisValue[] { "WorkerCount", "StartedAt", "Heartbeat" })
                             .ToStringArray().ToList()
                         );
-                    queues.Add(name,
-                        redis.ListRange(_storage.GetRedisKey($"server:{name}:queues"))
+                    queues.Add(serverName,
+                        redis.ListRange(_storage.GetRedisKey($"server:{serverName}:queues"))
                             .ToStringArray().ToList()
                         );
                 }
@@ -636,8 +635,7 @@ namespace Hangfire.Redis
 				var i = 8;
                 foreach (var queue in queues)
                 {
-                    var queueName = queue;
-                    tasks[i] = pipeline.ListLengthAsync(_storage.GetRedisKey($"queue:{queueName}"), CommandFlags.HighPriority)
+                    tasks[i] = pipeline.ListLengthAsync(_storage.GetRedisKey($"queue:{queue}"), CommandFlags.HighPriority)
 						.ContinueWith(x => { lock (stats) { stats.Enqueued += x.Result; } });
 					i++;
                 }

--- a/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
+++ b/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
@@ -554,7 +554,7 @@ namespace Hangfire.Redis
 
             var pipeline = redis.CreateBatch();
 			var tasks = new List<Task>(jobIds.Length * 2);
-            foreach (var jobId in jobIds)
+            foreach (var jobId in jobIds.Distinct())
             {
 				var jobTask = pipeline.HashGetAsync(
                         _storage.GetRedisKey($"job:{jobId}"),

--- a/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
+++ b/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
@@ -29,57 +29,65 @@ namespace Hangfire.Redis
 {
     internal class RedisMonitoringApi : IMonitoringApi
     {
+        private readonly RedisStorage _storage;
         private readonly IDatabase _database;
 
-		public RedisMonitoringApi([NotNull] IDatabase database)
+		public RedisMonitoringApi([NotNull] RedisStorage storage, [NotNull] IDatabase database)
         {
-			if (database == null) throw new ArgumentNullException("database");
+            if (storage == null) throw new ArgumentNullException(nameof(storage));
+			if (database == null) throw new ArgumentNullException(nameof(database));
 
+            _storage = storage;
 			_database = database;
         }
 
         public long ScheduledCount()
         {
             return UseConnection(redis =>
-                redis.SortedSetLength(RedisStorage.Prefix+"schedule"));
+                redis.SortedSetLength(_storage.GetRedisKey("schedule")));
         }
 
-        public long EnqueuedCount(string queue)
+        public long EnqueuedCount([NotNull] string queue)
         {
-            return UseConnection(redis =>
-                redis.ListLength(RedisStorage.Prefix + string.Format("queue:{0}", queue)));
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
+
+            return UseConnection(redis => redis.ListLength(_storage.GetRedisKey($"queue:{queue}")));
         }
 
-        public long FetchedCount(string queue)
+        public long FetchedCount([NotNull] string queue)
         {
-            return UseConnection(redis =>
-                redis.ListLength(RedisStorage.Prefix + string.Format("queue:{0}:dequeued", queue)));
-        }
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
 
-        public long FailedCount()
-        {
-            return UseConnection(redis => redis.SortedSetLength(RedisStorage.Prefix + "failed"));
+            return UseConnection(redis => redis.ListLength(_storage.GetRedisKey($"queue:{queue}:dequeued")));
         }
 
         public long ProcessingCount()
         {
-            return UseConnection(redis => redis.SortedSetLength(RedisStorage.Prefix + "processing"));
+            return UseConnection(redis => redis.SortedSetLength(_storage.GetRedisKey("processing")));
+        }
+        
+        public long SucceededListCount()
+        {
+            return UseConnection(redis => redis.ListLength(_storage.GetRedisKey("succeeded")));
         }
 
+        public long FailedCount()
+        {
+            return UseConnection(redis => redis.SortedSetLength(_storage.GetRedisKey("failed")));
+        }
+        
         public long DeletedListCount()
         {
-            return UseConnection(redis => redis.ListLength(RedisStorage.Prefix + "deleted"));
+            return UseConnection(redis => redis.ListLength(_storage.GetRedisKey("deleted")));
         }
 
-        public JobList<ProcessingJobDto> ProcessingJobs(
-            int from, int count)
+        public JobList<ProcessingJobDto> ProcessingJobs(int from, int count)
         {
             return UseConnection(redis =>
             {
-                var jobIds = redis.SortedSetRangeByRank(
-                    RedisStorage.Prefix + "processing",
-                    from,
-                    from + count - 1).ToStringArray();
+                var jobIds = redis
+                    .SortedSetRangeByRank(_storage.GetRedisKey("processing"), from, from + count - 1)
+                    .ToStringArray();
 
                 return new JobList<ProcessingJobDto>(GetJobsWithProperties(redis,
                     jobIds,
@@ -102,10 +110,9 @@ namespace Hangfire.Redis
         {
             return UseConnection(redis =>
             {
-                var scheduledJobs = redis.SortedSetRangeByRankWithScores(
-                    RedisStorage.Prefix + "schedule",
-                    from,
-                    from + count - 1).ToList();
+                var scheduledJobs = redis
+                    .SortedSetRangeByRankWithScores(_storage.GetRedisKey("schedule"), from, from + count - 1)
+                    .ToList();
 
                 if (scheduledJobs.Count == 0)
                 {
@@ -122,12 +129,12 @@ namespace Hangfire.Redis
                 {
                     var job = scheduledJob;
 					tasks[i] = pipeline.HashGetAsync(
-								RedisStorage.Prefix + string.Format("job:{0}", job.Element),
+								_storage.GetRedisKey($"job:{job.Element}"),
 								new RedisValue[] { "Type", "Method", "ParameterTypes", "Arguments" })
 						.ContinueWith(x => jobs.Add(job.Element, x.Result.ToStringArray().ToList()));
 					i++;
 					tasks[i] = pipeline.HashGetAsync(
-								RedisStorage.Prefix + string.Format("job:{0}:state", job.Element),
+								_storage.GetRedisKey($"job:{job.Element}:state"),
 								new RedisValue[] { "State", "ScheduledAt" })
 						.ContinueWith(x => states.Add(job.Element, x.Result.ToStringArray().ToList()));
 					i++;
@@ -168,7 +175,10 @@ namespace Hangfire.Redis
         {
             return UseConnection(redis =>
             {
-                var serverNames = redis.SetMembers(RedisStorage.Prefix + "servers").Select(x => (string)x).ToList();
+                var serverNames = redis
+                    .SetMembers(_storage.GetRedisKey("servers"))
+                    .Select(x => (string)x)
+                    .ToList();
 
                 if (serverNames.Count == 0)
                 {
@@ -182,14 +192,13 @@ namespace Hangfire.Redis
                 {
                     var name = serverName;
                     servers.Add(name,
-                        redis.HashGet(RedisStorage.Prefix + string.Format("server:{0}", name), new RedisValue[] { "WorkerCount", "StartedAt", "Heartbeat" })
+                        redis.HashGet(_storage.GetRedisKey($"server:{name}"), new RedisValue[] { "WorkerCount", "StartedAt", "Heartbeat" })
                             .ToStringArray().ToList()
                         );
                     queues.Add(name,
-                        redis.ListRange(RedisStorage.Prefix + string.Format("server:{0}:queues", name))
+                        redis.ListRange(_storage.GetRedisKey($"server:{name}:queues"))
                             .ToStringArray().ToList()
                         );
-
                 }
 
 
@@ -208,10 +217,8 @@ namespace Hangfire.Redis
         {
             return UseConnection(redis =>
             {
-                var failedJobIds = redis.SortedSetRangeByRank(
-                    RedisStorage.Prefix + "failed",
-                    from,
-                    from + count - 1)
+                var failedJobIds = redis
+                    .SortedSetRangeByRank(_storage.GetRedisKey("failed"), from, from + count - 1)
 					.ToStringArray();
 
                 return GetJobsWithProperties(
@@ -236,10 +243,8 @@ namespace Hangfire.Redis
         {
             return UseConnection(redis =>
             {
-                var succeededJobIds = redis.ListRange(
-                    RedisStorage.Prefix + "succeeded",
-                    from,
-                    from + count - 1)
+                var succeededJobIds = redis
+                    .ListRange(_storage.GetRedisKey("succeeded"), from, from + count - 1)
 					.ToStringArray();
 
                 return GetJobsWithProperties(
@@ -260,14 +265,13 @@ namespace Hangfire.Redis
             });
         }
 
-        public JobList<DeletedJobDto> DeletedJobs(int @from, int count)
+        public JobList<DeletedJobDto> DeletedJobs(int from, int count)
         {
             return UseConnection(redis =>
             {
-                var deletedJobIds = redis.ListRange(
-                    RedisStorage.Prefix + "deleted",
-                    from,
-                    from + count - 1).ToStringArray();
+                var deletedJobIds = redis
+                    .ListRange(_storage.GetRedisKey("deleted"), from, from + count - 1)
+                    .ToStringArray();
 
                 return GetJobsWithProperties(
                     redis,
@@ -287,8 +291,11 @@ namespace Hangfire.Redis
         {
             return UseConnection(redis =>
             {
-                var queues = redis.SetMembers(RedisStorage.Prefix + "queues")
-					.Select(x=> (string)x).ToList();
+                var queues = redis
+                    .SetMembers(_storage.GetRedisKey("queues"))
+					.Select(x=> (string)x)
+                    .ToList();
+
                 var result = new List<QueueWithTopEnqueuedJobsDto>(queues.Count);
 
                 foreach (var queue in queues)
@@ -301,13 +308,13 @@ namespace Hangfire.Redis
 					var pipeline = redis.CreateBatch();
 					Task[] tasks = new Task[3];
 					tasks[0] = pipeline.ListRangeAsync(
-                            RedisStorage.Prefix + string.Format("queue:{0}", queue), -5, -1)
+                            _storage.GetRedisKey($"queue:{queue}"), -5, -1)
 							.ContinueWith(x => firstJobIds = x.Result.ToStringArray());
 
-                    tasks[1] = pipeline.ListLengthAsync(RedisStorage.Prefix + string.Format("queue:{0}", queue))
+                    tasks[1] = pipeline.ListLengthAsync(_storage.GetRedisKey($"queue:{queue}"))
 						.ContinueWith(x => length = x.Result);
 
-                    tasks[2] = pipeline.ListLengthAsync(RedisStorage.Prefix + string.Format("queue:{0}:dequeued", queue))
+                    tasks[2] = pipeline.ListLengthAsync(_storage.GetRedisKey($"queue:{queue}:dequeued"))
 						.ContinueWith(x => fetched = x.Result);
 
 					pipeline.Execute();
@@ -339,15 +346,15 @@ namespace Hangfire.Redis
             });
         }
 
-        public JobList<EnqueuedJobDto> EnqueuedJobs(
-            string queue, int from, int perPage)
+        public JobList<EnqueuedJobDto> EnqueuedJobs([NotNull] string queue, int from, int count)
         {
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
+
             return UseConnection(redis =>
             {
-                var jobIds = redis.ListRange(
-                    RedisStorage.Prefix + string.Format("queue:{0}", queue),
-                    from,
-                    from + perPage - 1).ToStringArray();
+                var jobIds = redis
+                    .ListRange(_storage.GetRedisKey($"queue:{queue}"), from, from + count - 1)
+                    .ToStringArray();
 
                 return GetJobsWithProperties(
                     redis,
@@ -364,14 +371,15 @@ namespace Hangfire.Redis
             });
         }
 
-        public JobList<FetchedJobDto> FetchedJobs(
-            string queue, int from, int perPage)
+        public JobList<FetchedJobDto> FetchedJobs([NotNull] string queue, int from, int count)
         {
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
+
             return UseConnection(redis =>
             {
-                var jobIds = redis.ListRange(
-                    RedisStorage.Prefix + string.Format("queue:{0}:dequeued", queue),
-                    from, from + perPage - 1).ToStringArray();
+                var jobIds = redis
+                    .ListRange(_storage.GetRedisKey($"queue:{queue}:dequeued"), from, from + count - 1)
+                    .ToStringArray();
 				RedisValue[] rk = new RedisValue[1];
 
                 return GetJobsWithProperties(
@@ -398,17 +406,24 @@ namespace Hangfire.Redis
             return UseConnection(redis => GetHourlyTimelineStats(redis, "failed"));
         }
 
-        public JobDetailsDto JobDetails(string jobId)
+        public JobDetailsDto JobDetails([NotNull] string jobId)
         {
+            if (jobId == null) throw new ArgumentNullException(nameof(jobId));
+
             return UseConnection(redis =>
             {
-                var job = redis.HashGetAll(RedisStorage.Prefix + string.Format("job:{0}", jobId)).ToStringDictionary();
+                var job = redis
+                    .HashGetAll(_storage.GetRedisKey($"job:{jobId}"))
+                    .ToStringDictionary();
+
                 if (job.Count == 0) return null;
 
                 var hiddenProperties = new[] { "Type", "Method", "ParameterTypes", "Arguments", "State", "CreatedAt", "Fetched" };
 
-                var historyList = redis.ListRange(RedisStorage.Prefix + string.Format("job:{0}:history", jobId))
-					.Select(x=> (string)x).ToList();
+                var historyList = redis
+                    .ListRange(_storage.GetRedisKey($"job:{jobId}:history"))
+					.Select(x => (string)x)
+                    .ToList();
                 
                 // history is in wrong order, fix this
                 historyList.Reverse();
@@ -457,9 +472,10 @@ namespace Hangfire.Redis
             });
         }
 
-        private Dictionary<DateTime, long> GetHourlyTimelineStats(
-            IDatabase redis, string type)
+        private Dictionary<DateTime, long> GetHourlyTimelineStats([NotNull] IDatabase redis, [NotNull] string type)
         {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
             var endDate = DateTime.UtcNow;
             var dates = new List<DateTime>();
             for (var i = 0; i < 24; i++)
@@ -468,7 +484,7 @@ namespace Hangfire.Redis
                 endDate = endDate.AddHours(-1);
             }
 
-            var keys = dates.Select(x => RedisStorage.Prefix + string.Format("stats:{0}:{1}", type, x.ToString("yyyy-MM-dd-HH"))).ToArray();
+            var keys = dates.Select(x => _storage.GetRedisKey($"stats:{type}:{x:yyyy-MM-dd-HH}")).ToArray();
             var valuesMap = redis.GetValuesMap(keys);
 
             var result = new Dictionary<DateTime, long>();
@@ -486,9 +502,10 @@ namespace Hangfire.Redis
             return result;
         }
 
-        private Dictionary<DateTime, long> GetTimelineStats(
-            IDatabase redis, string type)
+        private Dictionary<DateTime, long> GetTimelineStats([NotNull] IDatabase redis, [NotNull] string type)
         {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
             var endDate = DateTime.UtcNow.Date;
             var startDate = endDate.AddDays(-7);
             var dates = new List<DateTime>();
@@ -498,14 +515,13 @@ namespace Hangfire.Redis
                 dates.Add(endDate);
                 endDate = endDate.AddDays(-1);
             }
-
-            var stringDates = dates.Select(x => x.ToString("yyyy-MM-dd")).ToList();
-            var keys = stringDates.Select(x => RedisStorage.Prefix + string.Format("stats:{0}:{1}", type, x)).ToArray();
+            
+            var keys = dates.Select(x => _storage.GetRedisKey($"stats:{type}:{x:yyyy-MM-dd}")).ToArray();
 
             var valuesMap = redis.GetValuesMap(keys);
 
             var result = new Dictionary<DateTime, long>();
-            for (var i = 0; i < stringDates.Count; i++)
+            for (var i = 0; i < dates.Count; i++)
             {
                 long value;
                 if (!long.TryParse(valuesMap[valuesMap.Keys.ElementAt(i)], out value))
@@ -519,12 +535,16 @@ namespace Hangfire.Redis
         }
 
         private JobList<T> GetJobsWithProperties<T>(
-            IDatabase redis,
-            string[] jobIds,
-            string[] properties,
+            [NotNull] IDatabase redis,
+            [NotNull] string[] jobIds,
+            [NotNull] string[] properties,
             string[] stateProperties,
-            Func<Job, List<string>, List<string>, T> selector)
+            [NotNull] Func<Job, List<string>, List<string>, T> selector)
         {
+            if (jobIds == null) throw new ArgumentNullException(nameof(jobIds));
+            if (properties == null) throw new ArgumentNullException(nameof(properties));
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+
             if (jobIds.Length == 0) return new JobList<T>(new List<KeyValuePair<string, T>>());
 
             var jobs = new Dictionary<string, Task<RedisValue[]>>(jobIds.Length, StringComparer.OrdinalIgnoreCase);
@@ -537,14 +557,18 @@ namespace Hangfire.Redis
             foreach (var jobId in jobIds)
             {
                 var id = jobId;
-				var jobTask=pipeline.HashGetAsync(
-                                RedisStorage.Prefix + string.Format("job:{0}", id),
-								properties.Union(new[] { "Type", "Method", "ParameterTypes", "Arguments" }).Select(x=> (RedisValue)x).ToArray());
+				var jobTask = pipeline.HashGetAsync(
+                        _storage.GetRedisKey($"job:{id}"),
+                        properties.Union(new[] { "Type", "Method", "ParameterTypes", "Arguments" })
+                    .Select(x => (RedisValue)x)
+                    .ToArray());
 				tasks.Add(jobTask);
                 jobs.Add(jobId, jobTask);
 				if (stateProperties != null)
 				{
-                    var taskStateJob = pipeline.HashGetAsync(RedisStorage.Prefix + string.Format("job:{0}:state", id), stateProperties.Select(x => (RedisValue)x).ToArray());
+                    var taskStateJob = pipeline.HashGetAsync(
+                        _storage.GetRedisKey($"job:{id}:state"), 
+                        stateProperties.Select(x => (RedisValue)x).ToArray());
 					tasks.Add(taskStateJob);
                     states.Add(jobId, taskStateJob);
 				}
@@ -574,50 +598,46 @@ namespace Hangfire.Redis
 			return jobList;
         }
 
-        public long SucceededListCount()
-        {
-            return UseConnection(redis => redis.ListLength(RedisStorage.Prefix + "succeeded"));
-        }
-
         public StatisticsDto GetStatistics()
         {
             return UseConnection(redis =>
             {
                 var stats = new StatisticsDto();
 
-                var queues = redis.SetMembers(RedisStorage.Prefix + "queues", CommandFlags.HighPriority);
+                var queues = redis.SetMembers(_storage.GetRedisKey("queues"), CommandFlags.HighPriority);
 
 				var pipeline = redis.CreateBatch();
 				var tasks = new Task[queues.Length + 8];
 
-                tasks[0] = pipeline.SetLengthAsync(RedisStorage.Prefix + "servers", CommandFlags.HighPriority)
+                tasks[0] = pipeline.SetLengthAsync(_storage.GetRedisKey("servers"), CommandFlags.HighPriority)
 					.ContinueWith(x=> stats.Servers = x.Result);
 
-                tasks[1] = pipeline.SetLengthAsync(RedisStorage.Prefix + "queues", CommandFlags.HighPriority)
+                tasks[1] = pipeline.SetLengthAsync(_storage.GetRedisKey("queues"), CommandFlags.HighPriority)
                     .ContinueWith(x => stats.Queues = x.Result);
 
-            tasks[2] = pipeline.SortedSetLengthAsync(RedisStorage.Prefix + "schedule", flags: CommandFlags.HighPriority)
+                tasks[2] = pipeline.SortedSetLengthAsync(_storage.GetRedisKey("schedule"), flags: CommandFlags.HighPriority)
 					.ContinueWith(x => stats.Scheduled = x.Result);
 
-                tasks[3] = pipeline.SortedSetLengthAsync(RedisStorage.Prefix + "processing", flags: CommandFlags.HighPriority)
+                tasks[3] = pipeline.SortedSetLengthAsync(_storage.GetRedisKey("processing"), flags: CommandFlags.HighPriority)
 					.ContinueWith(x => stats.Processing = x.Result);
 
-                tasks[4] = pipeline.StringGetAsync(RedisStorage.Prefix + "stats:succeeded", CommandFlags.HighPriority)
+                tasks[4] = pipeline.StringGetAsync(_storage.GetRedisKey("stats:succeeded"), CommandFlags.HighPriority)
                     .ContinueWith(x => stats.Succeeded = long.Parse(x.Result.HasValue ?  (string)x.Result: "0"));
 
-                tasks[5] = pipeline.SortedSetLengthAsync(RedisStorage.Prefix + "failed", flags: CommandFlags.HighPriority)
+                tasks[5] = pipeline.SortedSetLengthAsync(_storage.GetRedisKey("failed"), flags: CommandFlags.HighPriority)
 					.ContinueWith(x => stats.Failed = x.Result);
 
-                tasks[6] = pipeline.StringGetAsync(RedisStorage.Prefix + "stats:deleted", CommandFlags.HighPriority)
+                tasks[6] = pipeline.StringGetAsync(_storage.GetRedisKey("stats:deleted"), CommandFlags.HighPriority)
 					.ContinueWith(x => stats.Deleted = long.Parse(x.Result.HasValue ?  (string)x.Result : "0"));
 
-                tasks[7] = pipeline.SortedSetLengthAsync(RedisStorage.Prefix + "recurring-jobs", flags: CommandFlags.HighPriority)
+                tasks[7] = pipeline.SortedSetLengthAsync(_storage.GetRedisKey("recurring-jobs"), flags: CommandFlags.HighPriority)
                     .ContinueWith(x => stats.Recurring = x.Result);
+
 				var i = 8;
                 foreach (var queue in queues)
                 {
                     var queueName = queue;
-                    tasks[i] = pipeline.ListLengthAsync(RedisStorage.Prefix + string.Format("queue:{0}", queueName), CommandFlags.HighPriority)
+                    tasks[i] = pipeline.ListLengthAsync(_storage.GetRedisKey($"queue:{queueName}"), CommandFlags.HighPriority)
 						.ContinueWith(x => stats.Enqueued += x.Result);
 					i++;
                 }

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -122,7 +122,7 @@ namespace Hangfire.Redis
             yield return _subscription;
         }
 
-        public DashboardMetric GetDashboardMetricFromRedisInfo(string title, string key)
+        public static DashboardMetric GetDashboardMetricFromRedisInfo(string title, string key)
         {
             return new DashboardMetric("redis:" + key, title, (razorPage) =>
             {

--- a/Hangfire.Redis.StackExchange/RedisStorageExtensions.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorageExtensions.cs
@@ -36,7 +36,7 @@ namespace Hangfire
             RedisStorageOptions options = null)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-            if (connectionMultiplexer == null) throw new ArgumentNullException("connectionMultiplexer");
+            if (connectionMultiplexer == null) throw new ArgumentNullException(nameof(connectionMultiplexer));
             var storage = new RedisStorage(connectionMultiplexer, options);
             return configuration.UseStorage(storage);
         }

--- a/Hangfire.Redis.Tests/ExpiredJobsWatcherFacts.cs
+++ b/Hangfire.Redis.Tests/ExpiredJobsWatcherFacts.cs
@@ -25,34 +25,32 @@ namespace Hangfire.Redis.Tests
         [Fact]
         public void Ctor_ThrowsAnException_WhenStorageIsNull()
         {
-            var exception = Assert.Throws<ArgumentNullException>(
+            Assert.Throws<ArgumentNullException>("storage",
                 () => new ExpiredJobsWatcher(null, CheckInterval));
-
-            Assert.Equal("storage", exception.ParamName);
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenCheckIntervalIsZero()
         {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            Assert.Throws<ArgumentOutOfRangeException>("checkInterval",
                 () => new ExpiredJobsWatcher(_storage, TimeSpan.Zero));
-
-            Assert.Equal("checkInterval", exception.ParamName);
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenCheckIntervalIsNegative()
         {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            Assert.Throws<ArgumentOutOfRangeException>("checkInterval",
                 () => new ExpiredJobsWatcher(_storage, TimeSpan.FromSeconds(-1)));
-
-            Assert.Equal("checkInterval", exception.ParamName);
         }
 
         [Fact, CleanRedis]
         public void Execute_DeletesNonExistingJobs()
         {
             var redis = RedisUtils.CreateClient();
+
+            Assert.Equal(0, redis.ListLength("{hangfire}:succeeded"));
+            Assert.Equal(0, redis.ListLength("{hangfire}:deleted"));
+
             // Arrange
             redis.ListRightPush("{hangfire}:succeded", "my-job");
             redis.ListRightPush("{hangfire}:deleted", "other-job");
@@ -89,8 +87,10 @@ namespace Hangfire.Redis.Tests
             Assert.Equal(1, redis.ListLength("{hangfire}:succeeded"));
             Assert.Equal(1, redis.ListLength("{hangfire}:deleted"));
         }
-        
+
+#pragma warning disable 618
         private IServerComponent CreateWatcher()
+#pragma warning restore 618
         {
             return new ExpiredJobsWatcher(_storage, CheckInterval);
         }

--- a/Hangfire.Redis.Tests/FetchedJobsWatcherFacts.cs
+++ b/Hangfire.Redis.Tests/FetchedJobsWatcherFacts.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using Hangfire.Common;
 using Xunit;
+using System.Linq;
 
 namespace Hangfire.Redis.Tests
 {
@@ -64,7 +65,7 @@ namespace Hangfire.Redis.Tests
             Assert.Equal("my-job", listEntry);
 
             var job = redis.HashGetAll("{hangfire}:job:my-job");
-            Assert.False(job.ContainsKey("Fetched"));
+            Assert.False(job.Any(x => x.Name == "Fetched"));
         }
 
         [Fact, CleanRedis]
@@ -104,7 +105,7 @@ namespace Hangfire.Redis.Tests
             Assert.Equal(1, redis.ListLength("{hangfire}:queue:my-queue"));
 
             var job = redis.HashGetAll("{hangfire}:job:my-job");
-            Assert.False(job.ContainsKey("Checked"));
+            Assert.False(job.Any(x => x.Name == "Checked"));
         }
 
         [Fact, CleanRedis]

--- a/Hangfire.Redis.Tests/FetchedJobsWatcherFacts.cs
+++ b/Hangfire.Redis.Tests/FetchedJobsWatcherFacts.cs
@@ -24,28 +24,22 @@ namespace Hangfire.Redis.Tests
         [Fact]
         public void Ctor_ThrowsAnException_WhenStorageIsNull()
         {
-            var exception = Assert.Throws<ArgumentNullException>(
+            Assert.Throws<ArgumentNullException>("storage",
                 () => new FetchedJobsWatcher(null, InvisibilityTimeout));
-
-            Assert.Equal("storage", exception.ParamName);
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenInvisibilityTimeoutIsZero()
         {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            Assert.Throws<ArgumentOutOfRangeException>("invisibilityTimeout",
                 () => new FetchedJobsWatcher(_storage, TimeSpan.Zero));
-
-            Assert.Equal("invisibilityTimeout", exception.ParamName);
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenInvisibilityTimeoutIsNegative()
         {
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            Assert.Throws<ArgumentOutOfRangeException>("invisibilityTimeout",
                 () => new FetchedJobsWatcher(_storage, TimeSpan.FromSeconds(-1)));
-
-            Assert.Equal("invisibilityTimeout", exception.ParamName);
         }
 
         [Fact]

--- a/Hangfire.Redis.Tests/Hangfire.Redis.Tests.csproj
+++ b/Hangfire.Redis.Tests/Hangfire.Redis.Tests.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170427-09" />
-    <PackageReference Include="Moq" Version="4.7.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
   </ItemGroup>

--- a/Hangfire.Redis.Tests/RedisSubscriptionFacts.cs
+++ b/Hangfire.Redis.Tests/RedisSubscriptionFacts.cs
@@ -1,4 +1,5 @@
-﻿using StackExchange.Redis;
+﻿using Moq;
+using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,23 +14,38 @@ namespace Hangfire.Redis.Tests
     public class RedisSubscriptionFacts
     {
         private readonly CancellationTokenSource _cts;
+        private readonly RedisStorage _storage;
+        private readonly Mock<ISubscriber> _subscriber;
+
         public RedisSubscriptionFacts()
         {
             _cts = new CancellationTokenSource();
+
+            var options = new RedisStorageOptions() { Db = RedisUtils.GetDb() };
+            _storage = new RedisStorage(RedisUtils.GetHostAndPort(), options);
+
+            _subscriber = new Mock<ISubscriber>();
         }
+        
+        [Fact]
+        public void Ctor_ThrowAnException_WhenStorageIsNull()
+        {
+            Assert.Throws<ArgumentNullException>("storage",
+                () => new RedisSubscription(null, _subscriber.Object));
+        }
+
         [Fact]
         public void Ctor_ThrowAnException_WhenSubscriberIsNull()
         {
-            var exception = Assert.Throws<ArgumentNullException>(
-                () => new RedisSubscription(null));
-            Assert.Equal("subscriber", exception.ParamName);
+            Assert.Throws<ArgumentNullException>("subscriber",
+                () => new RedisSubscription(_storage, null));
         }
 
         public void WaitForJob_WaitForTheTimeout()
         {
             //Arrange
             Stopwatch sw = new Stopwatch();
-            var subscription = new RedisSubscription(RedisUtils.CreateSubscriber());
+            var subscription = new RedisSubscription(_storage, RedisUtils.CreateSubscriber());
             var timeout = TimeSpan.FromMilliseconds(100);
             sw.Start();
 


### PR DESCRIPTION
- Make `GetDashboardMetricFromRedisInfo` static (to add dashboard metrics without instantiating `RedisStorage`)
- Remove static `Prefix` field from `RedisStorage` (to allow using multiple instances simultaneously)
- Add null checks for arguments
- Use `nameof()` instead of hard-coded argument names everywhere
- Rule out possible race conditions in `RedisMonitoringApi`
- Suppress deprecation warnings for `IServerComponent` implementations