### PR TITLE
Removed expiration of lock key

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisLock.cs
+++ b/Hangfire.Redis.StackExchange/RedisLock.cs
@@ -40,7 +40,7 @@ namespace Hangfire.Redis
             DateTime lockExpirationTime = DateTime.UtcNow +timeOut;
             while (DateTime.UtcNow < lockExpirationTime)
             {
-                if (_redis.LockTake(key, owner, timeOut))
+                if (_redis.LockTake(key, owner))
                     return;
                 //assumes that a second call made by the same owner means an extension request
                 var lockOwner = _redis.LockQuery(key);

--- a/Hangfire.Redis.StackExchange/RedisLock.cs
+++ b/Hangfire.Redis.StackExchange/RedisLock.cs
@@ -40,7 +40,7 @@ namespace Hangfire.Redis
             DateTime lockExpirationTime = DateTime.UtcNow +timeOut;
             while (DateTime.UtcNow < lockExpirationTime)
             {
-                if (_redis.LockTake(key, owner))
+                if (_redis.LockTake(key, owner, TimeSpan.MaxValue))
                     return;
                 //assumes that a second call made by the same owner means an extension request
                 var lockOwner = _redis.LockQuery(key);


### PR DESCRIPTION
The key being used for a lock was being expired at the same time as the timeout for the subsequent lock timeouts. This meant that a lock for would expire basically as soon as the subsequent job waiting for the lock would stop. More often than not, this meant the job that is awaiting the lock would actually acquire the lock while the first job that obtained it was still executing.