### PR TITLE
Enable sliding expiration for distributed locks

### DIFF
--- a/Hangfire.Redis.StackExchange/FetchedJobsWatcher.cs
+++ b/Hangfire.Redis.StackExchange/FetchedJobsWatcher.cs
@@ -72,13 +72,11 @@ namespace Hangfire.Redis
         {
             // Allowing only one server at a time to process the timed out
             // jobs from the specified queue.
-            Logger.DebugFormat(
-                "Acquiring the lock for the fetched list of the '{0}' queue...", queue);
+            Logger.DebugFormat("Acquiring the lock for the fetched list of the '{0}' queue...", queue);
 
-            using (new RedisLock(connection.Redis, _storage.GetRedisKey($"queue:{queue}:dequeued:lock"), _storage.Identity + Thread.CurrentThread.ManagedThreadId, _options.FetchedLockTimeout))
+            using (RedisLock.Acquire(connection.Redis, _storage.GetRedisKey($"queue:{queue}:dequeued:lock"), _options.FetchedLockTimeout))
             {
-                Logger.DebugFormat(
-                    "Looking for timed out jobs in the '{0}' queue...", queue);
+                Logger.DebugFormat("Looking for timed out jobs in the '{0}' queue...", queue);
 
                 var jobIds = connection.Redis.ListRange(_storage.GetRedisKey($"queue:{queue}:dequeued"));
 

--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -31,24 +31,20 @@ namespace Hangfire.Redis
     {
         private readonly RedisStorage _storage;
         private readonly RedisSubscription _subscription;
-        private readonly string _jobStorageIdentity;
         private readonly TimeSpan _fetchTimeout = TimeSpan.FromMinutes(3);
 
         public RedisConnection(
-            [NotNull] RedisStorage storage, 
-            [NotNull] IDatabase redis, 
-            [NotNull] RedisSubscription subscription, 
-            [NotNull] string jobStorageIdentity, 
+            [NotNull] RedisStorage storage,
+            [NotNull] IDatabase redis,
+            [NotNull] RedisSubscription subscription,
             TimeSpan fetchTimeout)
         {
             if (storage == null) throw new ArgumentNullException(nameof(storage));
             if (redis == null) throw new ArgumentNullException(nameof(redis));
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
-            if (jobStorageIdentity == null) throw new ArgumentNullException(nameof(jobStorageIdentity));
 
             _storage = storage;
             _subscription = subscription;
-            _jobStorageIdentity = jobStorageIdentity;
             _fetchTimeout = fetchTimeout;
 
             Redis = redis;
@@ -58,7 +54,7 @@ namespace Hangfire.Redis
         
         public override IDisposable AcquireDistributedLock([NotNull] string resource, TimeSpan timeout)
         {
-            return new RedisLock(Redis, _storage.GetRedisKey(resource), _jobStorageIdentity + Thread.CurrentThread.ManagedThreadId, timeout);
+            return RedisLock.Acquire(Redis, _storage.GetRedisKey(resource), timeout);
         }
 
         public override void AnnounceServer([NotNull] string serverId, [NotNull] ServerContext context)

--- a/Hangfire.Redis.StackExchange/RedisLock.cs
+++ b/Hangfire.Redis.StackExchange/RedisLock.cs
@@ -15,67 +15,146 @@
 // License along with Hangfire.Redis.StackExchange. If not, see <http://www.gnu.org/licenses/>.
 
 using Hangfire.Annotations;
+using Hangfire.Storage;
 using StackExchange.Redis;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
 namespace Hangfire.Redis
 {
-    
     internal class RedisLock : IDisposable
     {
-        readonly IDatabase _redis;
-        readonly RedisKey _key;
-        readonly RedisValue _owner;
-        private bool isRoot = true;
-        public RedisLock([NotNull]IDatabase redis, [NotNull]RedisKey key, [NotNull]RedisValue owner, [NotNull]TimeSpan timeOut)
+        private static readonly TimeSpan DefaultHoldDuration = TimeSpan.FromSeconds(30);
+        private static readonly string OwnerId = Guid.NewGuid().ToString();
+
+#if NET45
+        /// <summary>
+        /// Drop-in implementation of AsyncLocal for NET 4.5
+        /// </summary>
+        private class AsyncLocal<T>
+        {
+            private readonly string __name = Guid.NewGuid().ToString();
+
+            public T Value
+            {
+                get
+                {
+                    var value = System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(__name);
+                    return value == null ? default(T) : (T)value;
+                }
+                set
+                {
+                    System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(__name, value);
+                }
+            }
+        }
+#endif
+        
+        private static AsyncLocal<ISet<RedisKey>> _heldLocks = new AsyncLocal<ISet<RedisKey>>();
+
+        private static ISet<RedisKey> HeldLocks
+        {
+            get
+            {
+                var value = _heldLocks.Value;
+                if (value == null)
+                    _heldLocks.Value = value = new HashSet<RedisKey>();
+                return value;
+            }
+        }
+
+        private readonly IDatabase _redis;
+        private readonly RedisKey _key;
+        private readonly bool _holdsLock;
+        private volatile bool _isDisposed = false;
+        private readonly Timer _slidingExpirationTimer;
+
+        private RedisLock([NotNull] IDatabase redis, RedisKey key, bool holdsLock, TimeSpan holdDuration)
         {
             _redis = redis;
             _key = key;
-            _owner = owner;
+            _holdsLock = holdsLock;
 
-            //The comparison below uses timeOut as a max timeSpan in waiting Lock
-            int i = 0;
-            DateTime lockExpirationTime = DateTime.UtcNow +timeOut;
-            while (DateTime.UtcNow < lockExpirationTime)
+            if (holdsLock)
             {
-                if (_redis.LockTake(key, owner, timeOut))
-                    return;
-                //assumes that a second call made by the same owner means an extension request
-                var lockOwner = _redis.LockQuery(key);
-                
-                if (lockOwner.Equals(owner))
-                {
-                    //extends the lock only for the remaining time
-                    var ttl = redis.KeyTimeToLive(key) ?? TimeSpan.Zero;
-                    var extensionTTL = lockExpirationTime - DateTime.UtcNow;
-                    if (extensionTTL > ttl)
-                    {
-                        Debug.WriteLine("Extending lock {0} - {1} by {2}", _key, _owner, (extensionTTL));
-                        _redis.LockExtend(key, owner, extensionTTL);
-                    }
-                    isRoot = false;
-                    return;
-                }
-                SleepBackOffMultiplier(i);
-                i++;
+                HeldLocks.Add(_key);
+
+                // start sliding expiration timer at half timeout intervals
+                var halfLockHoldDuration = TimeSpan.FromTicks(holdDuration.Ticks / 2);
+                _slidingExpirationTimer = new Timer(ExpirationTimerTick, holdDuration, halfLockHoldDuration, halfLockHoldDuration);
             }
-            throw new TimeoutException(string.Format("Lock on {0} with owner identifier {1} Exceeded timeout of {2}", key, owner.ToString(), timeOut));
+        }
+
+        private void ExpirationTimerTick(object state)
+        {
+            if (!_isDisposed)
+            {
+                _redis.LockExtend(_key, OwnerId, (TimeSpan)state);
+            }
         }
 
         public void Dispose()
         {
-            if (isRoot && !_redis.LockRelease(_key, _owner))
-                Debug.WriteLine("Lock {0} - {1} already timed out", _key, _owner);
+            if (_holdsLock)
+            {
+                _isDisposed = true;
+                _slidingExpirationTimer.Dispose();
+
+                if (!_redis.LockRelease(_key, OwnerId))
+                {
+                    Debug.WriteLine("Lock {0} already timed out", _key);
+                }
+
+                HeldLocks.Remove(_key);
+            }
         }
 
-        private static void SleepBackOffMultiplier(int i)
+        public static IDisposable Acquire([NotNull] IDatabase redis, RedisKey key, TimeSpan timeOut)
         {
-            //exponential/random retry back-off.
+            return Acquire(redis, key, timeOut, DefaultHoldDuration);
+        }
+
+        internal static IDisposable Acquire([NotNull] IDatabase redis, RedisKey key, TimeSpan timeOut, TimeSpan holdDuration)
+        {
+            if (redis == null)
+                throw new ArgumentNullException(nameof(redis));
+
+            if (HeldLocks.Contains(key))
+            {
+                // lock is already held
+                return new RedisLock(redis, key, false, holdDuration);
+            }
+
+            // The comparison below uses timeOut as a max timeSpan in waiting Lock
+            var i = 0;
+            var lockExpirationTime = DateTime.UtcNow + timeOut;
+            do
+            {
+                if (redis.LockTake(key, OwnerId, holdDuration))
+                {
+                    // we have successfully acquired the lock
+                    return new RedisLock(redis, key, true, holdDuration);
+                }
+                
+                SleepBackOffMultiplier(i++, (int)(lockExpirationTime - DateTime.UtcNow).TotalMilliseconds);
+            }
+            while (DateTime.UtcNow < lockExpirationTime);
+
+            throw new DistributedLockTimeoutException($"Failed to acquire lock on {key} within given timeout ({timeOut})");
+        }
+
+        private static void SleepBackOffMultiplier(int i, int maxWait)
+        {
+            if (maxWait <= 0) return;
+
+            // exponential/random retry back-off.
             var rand = new Random(Guid.NewGuid().GetHashCode());
             var nextTry = rand.Next(
                 (int)Math.Pow(i, 2), (int)Math.Pow(i + 1, 2) + 1);
+
+            nextTry = Math.Min(nextTry, maxWait);
 
             Thread.Sleep(nextTry);
         }

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -31,7 +31,6 @@ namespace Hangfire.Redis
     {
         // Make sure in Redis Cluster all transaction are in the same slot !!
         private readonly RedisStorageOptions _options;
-        private readonly string _identity;
         private readonly IConnectionMultiplexer _connectionMultiplexer;
         private readonly RedisSubscription _subscription;
 
@@ -47,8 +46,7 @@ namespace Hangfire.Redis
             _options = options ?? new RedisStorageOptions();
 
             _connectionMultiplexer = connectionMultiplexer;
-
-            _identity = Guid.NewGuid().ToString();
+            
             _subscription = new RedisSubscription(this, _connectionMultiplexer.GetSubscriber());
         }
 
@@ -66,7 +64,6 @@ namespace Hangfire.Redis
             _connectionMultiplexer = ConnectionMultiplexer.Connect(connectionString);
             _connectionMultiplexer.PreserveAsyncOrder = false;
             
-            _identity = Guid.NewGuid().ToString();
             _subscription = new RedisSubscription(this, _connectionMultiplexer.GetSubscriber());
         }
 
@@ -77,9 +74,7 @@ namespace Hangfire.Redis
         internal int SucceededListSize => _options.SucceededListSize;
 
         internal int DeletedListSize => _options.DeletedListSize;
-
-        internal string Identity => _identity;
-
+        
         internal string SubscriptionChannel => _subscription.Channel;
 
         public override IMonitoringApi GetMonitoringApi()
@@ -89,7 +84,7 @@ namespace Hangfire.Redis
 
         public override IStorageConnection GetConnection()
         {
-            return new RedisConnection(this, _connectionMultiplexer.GetDatabase(Db), _subscription, _identity, _options.FetchTimeout);
+            return new RedisConnection(this, _connectionMultiplexer.GetDatabase(Db), _subscription, _options.FetchTimeout);
         }
 
 #pragma warning disable 618

--- a/Hangfire.Redis.Tests/RedisConnectionFacts.cs
+++ b/Hangfire.Redis.Tests/RedisConnectionFacts.cs
@@ -190,13 +190,13 @@ namespace Hangfire.Redis.Tests
                 Assert.Equal("Value2", result["Key2"]);
             });
         }
-
+        
         private void UseConnections(Action<IDatabase, RedisConnection> action)
         {
 			var redis = RedisUtils.CreateClient();
             var subscription = new RedisSubscription(_storage, RedisUtils.CreateSubscriber());
 
-            using (var connection = new RedisConnection(_storage, redis, subscription, Guid.NewGuid().ToString(), new RedisStorageOptions().FetchTimeout))
+            using (var connection = new RedisConnection(_storage, redis, subscription, new RedisStorageOptions().FetchTimeout))
             {
 				action(redis, connection);
             }
@@ -207,7 +207,7 @@ namespace Hangfire.Redis.Tests
             var redis = RedisUtils.CreateClient();
             var subscription = new RedisSubscription(_storage, RedisUtils.CreateSubscriber());
 
-            using (var connection = new RedisConnection(_storage, redis, subscription, Guid.NewGuid().ToString(), new RedisStorageOptions().FetchTimeout))
+            using (var connection = new RedisConnection(_storage, redis, subscription, new RedisStorageOptions().FetchTimeout))
             {
 				action(connection);
             }

--- a/Hangfire.Redis.Tests/RedisLockFacts.cs
+++ b/Hangfire.Redis.Tests/RedisLockFacts.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Hangfire.Storage;
+using StackExchange.Redis;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -12,94 +11,114 @@ namespace Hangfire.Redis.Tests
     {
 
         [Fact, CleanRedis]
-        public void AcquireAndDisposeLock()
+        public void AcquireInSequence()
         {
             var db = RedisUtils.CreateClient();
             
-            using (var testLock = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(1)))
+            using (var testLock = RedisLock.Acquire(db, "testLock", TimeSpan.FromMilliseconds(1)))
                 Assert.NotNull(testLock);
-            using (var testLock = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(1)))
+            using (var testLock = RedisLock.Acquire(db, "testLock", TimeSpan.FromMilliseconds(1)))
                 Assert.NotNull(testLock);
         }
 
         [Fact, CleanRedis]
-        public void ExtendsALock()
+        public void AcquireNested()
         {
             var db = RedisUtils.CreateClient();
 
-            using (var testLock = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(100)))
+            using (var testLock1 = RedisLock.Acquire(db, "testLock", TimeSpan.FromMilliseconds(100)))
             {
-                Assert.NotNull(testLock);
-                using (var testLock2 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(10)))
-                    Assert.NotNull(testLock2);
-            }
-        }
+                Assert.NotNull(testLock1);
 
-        [Fact, CleanRedis]
-        public void GetLockAfterAnotherTimeout()
-        {
-            var db = RedisUtils.CreateClient();
-
-            using (var testLock = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(50)))
-            {
-                Thread.Sleep(60);
-                using (var testLock2 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(10)))
-                    Assert.NotNull(testLock2);
-            }
-        }
-
-        [Fact, CleanRedis]
-        public void TwoContendingLocks()
-        {
-            var db = RedisUtils.CreateClient();
-
-            using (var testLock1 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(100)))
-                Assert.Throws<TimeoutException>(() => new RedisLock(db, "testLock", "otherOwner", TimeSpan.FromMilliseconds(10)));
-        }
-
-        [Fact, CleanRedis]
-        public void NestLock()
-        {
-            var db = RedisUtils.CreateClient();
-
-            using (var testLock1 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(100)))
-            {
-                using (var testLock2 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(100)))
-                { }
-
-            }
-        }
-
-        [Fact, CleanRedis]
-        public void NestLockDisposePreservesRoot()
-        {
-            var db = RedisUtils.CreateClient();
-
-            using (var testLock1 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(1000)))
-            {
-                using (var testLock2 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(1000)))
-                { }
-
-                Assert.Throws<TimeoutException>(() =>
+                using (var testLock2 = RedisLock.Acquire(db, "testLock", TimeSpan.FromMilliseconds(100)))
                 {
-                    using (var testLock2 = new RedisLock(db, "testLock", "otherOwner", TimeSpan.FromMilliseconds(1))) { };
-                });
+                    Assert.NotNull(testLock2);
+                }
             }
         }
 
         [Fact, CleanRedis]
-        public void ReleaseNestedAfterTimeout()
+        public void AcquireFromMultipleThreads()
         {
             var db = RedisUtils.CreateClient();
 
-            using (var testLock1 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(50)))
-            {
-                using (var testLock2 = new RedisLock(db, "testLock", "owner", TimeSpan.FromMilliseconds(1)))
-                { }
+            var sync = new ManualResetEventSlim();
 
-                Thread.Sleep(60);
-                using (var testLock2 = new RedisLock(db, "testLock", "otherOwner", TimeSpan.FromMilliseconds(1))) { };
-                Assert.True(true);
+            var thread1 = new Thread(state =>
+            {
+                using (var testLock1 = RedisLock.Acquire(db, "test", TimeSpan.FromMilliseconds(50)))
+                {
+                    // ensure nested lock release doesn't release parent lock
+                    using (var testLock2 = RedisLock.Acquire(db, "test", TimeSpan.FromMilliseconds(50)))
+                    { }
+
+                    sync.Set();
+                    Thread.Sleep(200);
+                }
+            });
+
+            var thread2 = new Thread(state =>
+            {
+                Assert.True(sync.Wait(1000));
+
+                Assert.Throws<DistributedLockTimeoutException>(() =>
+                {
+                    using (var testLock2 = RedisLock.Acquire(db, "test", TimeSpan.FromMilliseconds(50)))
+                    { }
+                });
+            });
+
+            thread1.Start();
+            thread2.Start();
+            thread1.Join();
+            thread2.Join();
+        }
+        
+        private async Task NestedTask(IDatabase db)
+        {
+            await Task.Yield();
+
+            using (var lestLock2 = RedisLock.Acquire(db, "test", TimeSpan.FromMilliseconds(10)))
+                Assert.NotNull(lestLock2);
+        }
+
+        [Fact, CleanRedis]
+        public async Task AcquireFromNestedTask()
+        {
+            var db = RedisUtils.CreateClient();
+
+            using (var lock1 = RedisLock.Acquire(db, "test", TimeSpan.FromMilliseconds(50)))
+            {
+                Assert.NotNull(lock1);
+
+                await Task.Delay(100);
+
+                await Task.Run(() => NestedTask(db));
+            }
+        }
+
+        [Fact, CleanRedis]
+        public void SlidingExpirationTest()
+        {
+            var db = RedisUtils.CreateClient();
+
+            using (var testLock1 = RedisLock.Acquire(db, "testLock", TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(100)))
+            {
+                Assert.NotNull(testLock1);
+
+                Thread.Sleep(250);
+
+                var thread = new Thread(state =>
+                {
+                    Assert.Throws<DistributedLockTimeoutException>(() =>
+                    {
+                        using (var testLock2 = RedisLock.Acquire(db, "testLock", TimeSpan.FromMilliseconds(100)))
+                        { }
+                    });
+                });
+
+                thread.Start();
+                thread.Join();
             }
         }
     }


### PR DESCRIPTION
Also, make them work correctly in async tasks when the thread could be switched anytime.