### PR TITLE
Fix null ref exception

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
+++ b/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
@@ -107,7 +107,7 @@ namespace Hangfire.Redis
                         InProcessingState = ProcessingState.StateName.Equals(
                             state[3], StringComparison.OrdinalIgnoreCase),
                     })
-					.Where(x=> x.Value.ServerId != null)
+					.Where(x=> x.Value?.ServerId != null)
 					.OrderBy(x => x.Value.StartedAt).ToList());
             });
         }


### PR DESCRIPTION
Here's the error:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Hangfire.Redis.RedisMonitoringApi.<>c.<ProcessingJobs>b__11_2(KeyValuePair`2 x)
   at System.Linq.Enumerable.WhereListIterator`1.ToArray()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.OrderedEnumerable`1.ToList()
   at Hangfire.Redis.RedisMonitoringApi.<>c__DisplayClass11_0.<ProcessingJobs>b__0(IDatabase redis)
   at Hangfire.Dashboard.Pages.ProcessingJobsPage.Execute()
   at Hangfire.Dashboard.RazorPage.TransformText(String body)
   at Hangfire.Dashboard.RazorPageDispatcher.Dispatch(DashboardContext context)
   at Hangfire.Dashboard.AspNetCoreDashboardMiddleware.Invoke(HttpContext httpContext)
```