### PR TITLE
Change from info to debug on WriteOptionsToLog

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -126,9 +126,9 @@ namespace Hangfire.Redis
 
         public override void WriteOptionsToLog(ILog logger)
         {
-            logger.Info("Using the following options for Redis job storage:");
+            logger.Debug("Using the following options for Redis job storage:");
 
-            logger.InfoFormat("ConnectionString: {0}\nDN: {1}", ConnectionString, Db);
+            logger.DebugFormat("ConnectionString: {0}\nDN: {1}", ConnectionString, Db);
         }
 
         public override string ToString()


### PR DESCRIPTION
If a password is used in the connection string, this ends up writing it to the logs in the default (info log level) configuration. This changes the log level to debug.