### PR TITLE
[Nuget] Update `StackExchange.Redis` to version `2.1.58`

### DIFF
--- a/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
+++ b/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
@@ -77,7 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="HangFire.Core" Version="1.7.11" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.30" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We got bit by a nasty bug in the old version; it was necessary for us to upgrade this. I imagine others will find the same.