### PR TITLE
Fix batching support

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -246,7 +246,8 @@ namespace Hangfire.Redis
         public override List<string> GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore, int count)
         {
             return Redis.SortedSetRangeByScore(_storage.GetRedisKey(key), fromScore, toScore, skip: 0, take: count)
-                .Select(x => x.HasValue ? x.ToString() : null)
+                .Where(x => x.HasValue)
+                .Select(x => x.ToString())
                 .ToList();
         }
 

--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -243,6 +243,13 @@ namespace Hangfire.Redis
                 .FirstOrDefault();
         }
 
+        public override List<string> GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore, int count)
+        {
+            return Redis.SortedSetRangeByScore(_storage.GetRedisKey(key), fromScore, toScore, skip: 0, take: count)
+                .Select(x => x.HasValue ? x.ToString() : null)
+                .ToList();
+        }
+
         public override long GetHashCount([NotNull] string key)
         {
             return Redis.HashLength(_storage.GetRedisKey(key));


### PR DESCRIPTION
GetFirstByLowestScoreFromSet with count is required within the RecurringJobScheduler in hangfire to correctly retrieve batches of recurring jobs. Without this method the RecurringJobScheduler retrieves the recurring jobs one at a time.

We had 1,200 recurring jobs 55 or so running every minute. Without this change the minute jobs ran every 5-7 minutes. With this change they run at their expected times.