### PR TITLE
Hides password in RedisStorage.ToString() method.

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -33,6 +33,7 @@ namespace Hangfire.Redis
         private readonly RedisStorageOptions _options;
         private readonly IConnectionMultiplexer _connectionMultiplexer;
         private readonly RedisSubscription _subscription;
+        private readonly ConfigurationOptions _redisOptions;
 
         public RedisStorage()
             : this("localhost:6379")
@@ -44,6 +45,7 @@ namespace Hangfire.Redis
             _options = options ?? new RedisStorageOptions();
 
             _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
+            _redisOptions = ConfigurationOptions.Parse(_connectionMultiplexer.Configuration);
             
             _subscription = new RedisSubscription(this, _connectionMultiplexer.GetSubscriber());
         }
@@ -52,11 +54,11 @@ namespace Hangfire.Redis
         {
             if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
 
-            var redisOptions = ConfigurationOptions.Parse(connectionString);
+            _redisOptions = ConfigurationOptions.Parse(connectionString);
 
             _options = options ?? new RedisStorageOptions
             {
-                Db = redisOptions.DefaultDatabase ?? 0
+                Db = _redisOptions.DefaultDatabase ?? 0
             };
 
             _connectionMultiplexer = ConnectionMultiplexer.Connect(connectionString);
@@ -131,7 +133,8 @@ namespace Hangfire.Redis
 
         public override string ToString()
         {
-            return string.Format("redis://{0}/{1}", ConnectionString, Db);
+            var connectionString = _redisOptions.ToString(includePassword: false);
+            return string.Format("redis://{0}/{1}", connectionString, Db);
         }
 
         internal string GetRedisKey([NotNull] string key)

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -128,7 +128,8 @@ namespace Hangfire.Redis
         {
             logger.Debug("Using the following options for Redis job storage:");
 
-            logger.DebugFormat("ConnectionString: {0}\nDN: {1}", ConnectionString, Db);
+            var connectionString = _redisOptions.ToString(includePassword: false);
+            logger.DebugFormat("ConnectionString: {0}\nDN: {1}", connectionString, Db);
         }
 
         public override string ToString()

--- a/Hangfire.Redis.Tests/RedisStorageFacts.cs
+++ b/Hangfire.Redis.Tests/RedisStorageFacts.cs
@@ -27,6 +27,14 @@ namespace Hangfire.Redis.Tests
             Assert.Equal(5, storage.Db);
         }
 
+        [Fact]
+        public void PasswordFromToStringIsNotShown()
+        {
+            string password = Guid.NewGuid().ToString("N");
+            var storage = new RedisStorage(String.Format("{0},password={1}", RedisUtils.GetHostAndPort(), password));
+            Assert.DoesNotContain(password, storage.ToString());
+        }
+        
         private RedisStorage CreateStorage()
         {
             var options = new RedisStorageOptions() { Db = RedisUtils.GetDb() };


### PR DESCRIPTION
# Fixes
- https://github.com/marcoCasamento/Hangfire.Redis.StackExchange/issues/115

# Before:
## Default console output (.Tostring)
![image](https://user-images.githubusercontent.com/5807256/192139158-a05c7ed4-1e27-4fe0-84b7-0684982c4472.png)

## WriteOptionsToLog
![image](https://user-images.githubusercontent.com/5807256/192141277-801b281b-643c-4934-9697-cd52dd8c0bcb.png)

## Hangfire dashboard
![image](https://user-images.githubusercontent.com/5807256/192138906-cf04444d-b326-43e1-90eb-0ab3321d8fe4.png)

# After:
## Default console output (.Tostring)
![image](https://user-images.githubusercontent.com/5807256/192139061-59d3ece1-d0a1-498a-929f-c2436ac0758d.png)

## WriteOptionsToLog
![image](https://user-images.githubusercontent.com/5807256/192141304-efffab86-d280-4a64-8176-ace96887a390.png)

## Hangfire dashboard
![image](https://user-images.githubusercontent.com/5807256/192138920-489665b1-b88b-48f3-b453-57300e34b601.png)

# Tests:
![image](https://user-images.githubusercontent.com/5807256/192141255-f222716e-5c7d-479a-95cf-8c6480109041.png)
