### PR TITLE
NuGet updates (StackExchange.Redis most importantly)

### DIFF
--- a/Hangfire.Redis.StackExchange.sln.DotSettings
+++ b/Hangfire.Redis.StackExchange.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hangfire/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
+++ b/Hangfire.Redis.StackExchange/Hangfire.Redis.StackExchange.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <PackageId>Hangfire.Redis.StackExchange</PackageId>
     <IsPackable>true</IsPackable>
-    <Version>1.8.6</Version>
-    <PackageVersion>1.8.6</PackageVersion>
+    <Version>1.8.7</Version>
+    <PackageVersion>1.8.7</PackageVersion>
     <Authors>Marco Casamento and contributors</Authors>
     <owners>marcocasamento</owners>
     <!--
@@ -81,8 +81,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.31" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.33" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
   </ItemGroup>
 
 </Project>

--- a/Hangfire.Redis.StackExchange/Properties/AssemblyInfo.cs
+++ b/Hangfire.Redis.StackExchange/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/Hangfire.Redis.StackExchange/RedisDatabaseExtensions.cs
+++ b/Hangfire.Redis.StackExchange/RedisDatabaseExtensions.cs
@@ -17,9 +17,7 @@
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 
 namespace Hangfire.Redis
 {

--- a/Hangfire.Redis.StackExchange/RedisInfoKeys.cs
+++ b/Hangfire.Redis.StackExchange/RedisInfoKeys.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Hangfire.Redis
+﻿namespace Hangfire.Redis
 {
     public class RedisInfoKeys
     {

--- a/Hangfire.Redis.Tests/ApplyStateContextMock.cs
+++ b/Hangfire.Redis.Tests/ApplyStateContextMock.cs
@@ -2,7 +2,6 @@
 using Hangfire.States;
 using Moq;
 using Hangfire.Common;
-using System.Reflection;
 
 namespace Hangfire.Redis.Tests
 {

--- a/Hangfire.Redis.Tests/ExpiredJobsWatcherFacts.cs
+++ b/Hangfire.Redis.Tests/ExpiredJobsWatcherFacts.cs
@@ -12,14 +12,14 @@ namespace Hangfire.Redis.Tests
         private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(1);
 
         private readonly RedisStorage _storage;
-		private readonly CancellationTokenSource _cts;
+        private readonly CancellationTokenSource _cts;
 
         public ExpiredJobsWatcherFacts()
         {
-            var options = new RedisStorageOptions() { Db = RedisUtils.GetDb() };
+            var options = new RedisStorageOptions() {Db = RedisUtils.GetDb()};
             _storage = new RedisStorage(RedisUtils.GetHostAndPort(), options);
-			_cts = new CancellationTokenSource();
-			_cts.Cancel();
+            _cts = new CancellationTokenSource();
+            _cts.Cancel();
         }
 
         [Fact]
@@ -56,15 +56,15 @@ namespace Hangfire.Redis.Tests
             redis.ListRightPush("{hangfire}:deleted", "other-job");
 
             var watcher = CreateWatcher();
-            
+
             // Act
             watcher.Execute(_cts.Token);
-            
+
             // Assert
             Assert.Equal(0, redis.ListLength("{hangfire}:succeeded"));
             Assert.Equal(0, redis.ListLength("{hangfire}:deleted"));
         }
-        
+
         [Fact, CleanRedis]
         public void Execute_DoesNotDeleteExistingJobs()
         {
@@ -73,16 +73,16 @@ namespace Hangfire.Redis.Tests
             redis.ListRightPush("{hangfire}:succeeded", "my-job");
             redis.HashSet("{hangfire}:job:my-job", "Fetched",
                 JobHelper.SerializeDateTime(DateTime.UtcNow.AddDays(-1)));
-            
+
             redis.ListRightPush("{hangfire}:deleted", "other-job");
             redis.HashSet("{hangfire}:job:other-job", "Fetched",
                 JobHelper.SerializeDateTime(DateTime.UtcNow.AddDays(-1)));
 
             var watcher = CreateWatcher();
-            
+
             // Act
             watcher.Execute(_cts.Token);
-            
+
             // Assert
             Assert.Equal(1, redis.ListLength("{hangfire}:succeeded"));
             Assert.Equal(1, redis.ListLength("{hangfire}:deleted"));

--- a/Hangfire.Redis.Tests/FetchedJobsWatcherFacts.cs
+++ b/Hangfire.Redis.Tests/FetchedJobsWatcherFacts.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using Hangfire.Common;
 using Xunit;
-using System.Linq;
 
 namespace Hangfire.Redis.Tests
 {
@@ -12,14 +11,14 @@ namespace Hangfire.Redis.Tests
         private static readonly TimeSpan InvisibilityTimeout = TimeSpan.FromSeconds(10);
 
         private readonly RedisStorage _storage;
-		private readonly CancellationTokenSource _cts;
+        private readonly CancellationTokenSource _cts;
 
         public FetchedJobsWatcherFacts()
         {
-            var options = new RedisStorageOptions() { Db = RedisUtils.GetDb() };
+            var options = new RedisStorageOptions() {Db = RedisUtils.GetDb()};
             _storage = new RedisStorage(RedisUtils.GetHostAndPort(), options);
-			_cts = new CancellationTokenSource();
-			_cts.Cancel();
+            _cts = new CancellationTokenSource();
+            _cts.Cancel();
         }
 
         [Fact]
@@ -46,7 +45,7 @@ namespace Hangfire.Redis.Tests
         [Fact]
         public void Execute_EnqueuesTimedOutJobs_AndDeletesThemFromFetchedList()
         {
-			var redis = RedisUtils.CreateClient();
+            var redis = RedisUtils.CreateClient();
             // Arrange
             redis.SetAdd("{hangfire}:queues", "my-queue");
             redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
@@ -56,12 +55,12 @@ namespace Hangfire.Redis.Tests
             var watcher = CreateWatcher();
 
             // Act
-			watcher.Execute(_cts.Token);
+            watcher.Execute(_cts.Token);
 
             // Assert
             Assert.Equal(0, redis.ListLength("{hangfire}:queue:my-queue:dequeued"));
 
-            var listEntry = (string)redis.ListRightPop("{hangfire}:queue:my-queue");
+            var listEntry = (string) redis.ListRightPop("{hangfire}:queue:my-queue");
             Assert.Equal("my-job", listEntry);
 
             var job = redis.HashGetAll("{hangfire}:job:my-job");
@@ -71,7 +70,7 @@ namespace Hangfire.Redis.Tests
         [Fact, CleanRedis]
         public void Execute_MarksDequeuedJobAsChecked_IfItHasNoFetchedFlagSet()
         {
-			var redis = RedisUtils.CreateClient();
+            var redis = RedisUtils.CreateClient();
             // Arrange
             redis.SetAdd("{hangfire}:queues", "my-queue");
             redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
@@ -79,7 +78,7 @@ namespace Hangfire.Redis.Tests
             var watcher = CreateWatcher();
 
             // Act
-			watcher.Execute(_cts.Token);
+            watcher.Execute(_cts.Token);
 
             Assert.NotNull(JobHelper.DeserializeNullableDateTime(
                 redis.HashGet("{hangfire}:job:my-job", "Checked")));
@@ -88,7 +87,7 @@ namespace Hangfire.Redis.Tests
         [Fact, CleanRedis]
         public void Execute_EnqueuesCheckedAndTimedOutJob_IfNoFetchedFlagSet()
         {
-			var redis = RedisUtils.CreateClient();
+            var redis = RedisUtils.CreateClient();
             // Arrange
             redis.SetAdd("{hangfire}:queues", "my-queue");
             redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
@@ -98,7 +97,7 @@ namespace Hangfire.Redis.Tests
             var watcher = CreateWatcher();
 
             // Act
-			watcher.Execute(_cts.Token);
+            watcher.Execute(_cts.Token);
 
             // Arrange
             Assert.Equal(0, redis.ListLength("{hangfire}:queue:my-queue:dequeued"));
@@ -112,11 +111,11 @@ namespace Hangfire.Redis.Tests
         public void Execute_DoesNotEnqueueTimedOutByCheckedFlagJob_IfFetchedFlagSet()
         {
             var redis = RedisUtils.CreateClient();
-            
+
             // Arrange
             redis.SetAdd("{hangfire}:queues", "my-queue");
             redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
-			redis.HashSet("{hangfire}:job:my-job", "Checked",
+            redis.HashSet("{hangfire}:job:my-job", "Checked",
                 JobHelper.SerializeDateTime(DateTime.UtcNow.AddDays(-1)));
             redis.HashSet("{hangfire}:job:my-job", "Fetched",
                 JobHelper.SerializeDateTime(DateTime.UtcNow));
@@ -124,11 +123,10 @@ namespace Hangfire.Redis.Tests
             var watcher = CreateWatcher();
 
             // Act
-			watcher.Execute(_cts.Token);
+            watcher.Execute(_cts.Token);
 
             // Assert
             Assert.Equal(1, redis.ListLength("{hangfire}:queue:my-queue:dequeued"));
-            
         }
 
         private FetchedJobsWatcher CreateWatcher()

--- a/Hangfire.Redis.Tests/Hangfire.Redis.Tests.csproj
+++ b/Hangfire.Redis.Tests/Hangfire.Redis.Tests.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.31" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Hangfire.Core" Version="1.7.33" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -29,6 +29,12 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Hangfire.Redis.Tests/RedisConnectionFacts.cs
+++ b/Hangfire.Redis.Tests/RedisConnectionFacts.cs
@@ -1,5 +1,4 @@
-﻿using Moq;
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/Hangfire.Redis.Tests/RedisFetchedJobFacts.cs
+++ b/Hangfire.Redis.Tests/RedisFetchedJobFacts.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Win32;
 using Moq;
 using Xunit;
 using StackExchange.Redis;

--- a/Hangfire.Redis.Tests/RedisSubscriptionFacts.cs
+++ b/Hangfire.Redis.Tests/RedisSubscriptionFacts.cs
@@ -1,11 +1,8 @@
 ﻿using Moq;
 using StackExchange.Redis;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Hangfire.Redis.Tests

--- a/Hangfire.Redis.Tests/RedisTest.cs
+++ b/Hangfire.Redis.Tests/RedisTest.cs
@@ -1,5 +1,4 @@
 ﻿using StackExchange.Redis;
-using System;
 using Xunit;
 
 namespace Hangfire.Redis.Tests

--- a/Hangfire.Redis.Tests/Utils/CleanRedisAttribute.cs
+++ b/Hangfire.Redis.Tests/Utils/CleanRedisAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using System.Threading;
-using Xunit;
 using Xunit.Sdk;
 
 namespace Hangfire.Redis.Tests

--- a/Hangfire.Redis.Tests/Utils/RedisUtils.cs
+++ b/Hangfire.Redis.Tests/Utils/RedisUtils.cs
@@ -1,7 +1,5 @@
 ﻿using StackExchange.Redis;
 using System;
-using System.Runtime.ExceptionServices;
-using System.Threading;
 
 namespace Hangfire.Redis.Tests
 {
@@ -14,11 +12,12 @@ namespace Hangfire.Redis.Tests
         private const string DefaultHost = "127.0.0.1";
         private const int DefaultPort = 6379;
         private const int DefaultDb = 1;
-		static Lazy<ConnectionMultiplexer> connection = null;
-		static RedisUtils()
-		{
-			connection = new Lazy<ConnectionMultiplexer>(() =>
-				{
+        static Lazy<ConnectionMultiplexer> connection = null;
+
+        static RedisUtils()
+        {
+            connection = new Lazy<ConnectionMultiplexer>(() =>
+                {
                     ConfigurationOptions options = new ConfigurationOptions
                     {
                         AllowAdmin = true,
@@ -27,17 +26,20 @@ namespace Hangfire.Redis.Tests
                     };
                     options.EndPoints.Add(GetHostAndPort());
                     return ConnectionMultiplexer.Connect(options);
-				}
-			);
-		}
+                }
+            );
+        }
+
         public static IDatabase CreateClient()
         {
-			return connection.Value.GetDatabase(DefaultDb);
+            return connection.Value.GetDatabase(DefaultDb);
         }
-		public static ISubscriber CreateSubscriber()
-		{
-			return connection.Value.GetSubscriber();
-		}
+
+        public static ISubscriber CreateSubscriber()
+        {
+            return connection.Value.GetSubscriber();
+        }
+
         public static string GetHostAndPort()
         {
             return String.Format("{0}:{1}", GetHost(), GetPort());

--- a/Hangfire.Redis.Tests/Utils/StaticFakeJobs.cs
+++ b/Hangfire.Redis.Tests/Utils/StaticFakeJobs.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Hangfire.Redis.Tests.Utils
 {

--- a/Hangfire.Redis.Tests/xunit.runner.json
+++ b/Hangfire.Redis.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Various cleanup
Tests are no longer parallelized
NET461 -> NET462 (no longer supported)

After trying to run the tests it became apparently that there are issues with the global locking between tests (CleanRedis attribute).  This seems to be some workaround instead of properly using a fixture?