### PR TITLE
Failed jobs page lists new items first

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
+++ b/Hangfire.Redis.StackExchange/RedisMonitoringApi.cs
@@ -225,7 +225,7 @@ namespace Hangfire.Redis.StackExchange
             return UseConnection(redis =>
             {
                 var failedJobIds = redis
-                    .SortedSetRangeByRank(_storage.GetRedisKey("failed"), from, from + count - 1)
+                    .SortedSetRangeByRank(_storage.GetRedisKey("failed"), from, from + count - 1, Order.Descending)
 					.ToStringArray();
 
                 return GetJobsWithProperties(


### PR DESCRIPTION
Most lists in the Hangfire dashboard are displayed with newest items first. An exception to this is the failed jobs page, which displays oldest items first. It would be very helpful for this page to display newest items first, since looking for recently failed jobs is one of the main use cases of the dashboard for many organizations.

The reason for this discrepancy appears to come down to the failed key using a different Redis data type. The failed key is stored as a sorted set, whereas the others (such as succeeded and deleted) are stored as lists. New items are added to the lists with LPUSH, so the newest item is index 0. When the LRANGE command is run, the first query starts at index 0 and returns the newest item first.

For the failed key, the oldest items are effectively at index 0, but that index is determined by the sorted set score, which is the Unix epoch second count here. Older items have lower values, so they're sorted first. So when the ZRANGE command is run, the first query starting at index 0 returns oldest items first.

This adds the REV option using Order.Descending, so that the failed query also returns newest items first.