### PR TITLE
Fix missing key prefixing

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -111,6 +111,7 @@ namespace Hangfire.Redis.StackExchange
             //the returned time is the time on the first server of the cluster
             return redisServer.Time();
         }
+        
         public override long GetSetCount([NotNull] IEnumerable<string> keys, int limit)
         {
             Task[] tasks = new Task[keys.Count()];
@@ -119,8 +120,8 @@ namespace Hangfire.Redis.StackExchange
             ConcurrentDictionary<string, long> results = new ConcurrentDictionary<string, long>();
             foreach (string key in keys)
             {
-                tasks[i] = batch.SortedSetLengthAsync(key, max: limit)
-                    .ContinueWith((Task<long> x) => results.TryAdd(key, x.Result));
+                tasks[i] = batch.SortedSetLengthAsync(_storage.GetRedisKey(key), max: limit)
+                    .ContinueWith((Task<long> x) => results.TryAdd(_storage.GetRedisKey(key), x.Result));
             }
             batch.Execute();
             Task.WaitAll(tasks);
@@ -129,9 +130,10 @@ namespace Hangfire.Redis.StackExchange
 
         public override bool GetSetContains([NotNull] string key, [NotNull] string value)
         {
-            var sortedSetEntries = Redis.SortedSetScan(key, value);
+            var sortedSetEntries = Redis.SortedSetScan(_storage.GetRedisKey(key), value);
             return sortedSetEntries.Any();
         }
+        
         public override string CreateExpiredJob(
             [NotNull] Job job,
             [NotNull] IDictionary<string, string> parameters,

--- a/Hangfire.Redis.Tests/RedisConnectionFacts.cs
+++ b/Hangfire.Redis.Tests/RedisConnectionFacts.cs
@@ -204,6 +204,31 @@ namespace Hangfire.Redis.Tests
             });
         }
 
+        [Fact]
+        public void SetCount_ReturnZeroIfSetDoesNotExists()
+        {
+            UseConnections((redis, connection) =>
+            {
+                var result = connection.GetSetCount("some-set");
+
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact, CleanRedis]
+        public void SetCount_ReturnNumberOfItems()
+        {
+            UseConnections((redis, connection) =>
+            {
+                redis.SortedSetAdd("{hangfire}:some-set", "1", 0);
+                redis.SortedSetAdd("{hangfire}:some-set", "2", 0);
+
+                var result = connection.GetSetCount("some-set");
+
+                Assert.Equal(2, result);
+            });
+        }
+
         [Fact, CleanRedis]
         public void SetContains_ReturnTrueIfContained()
         {
@@ -211,11 +236,12 @@ namespace Hangfire.Redis.Tests
             {
                 redis.SortedSetAdd("{hangfire}:some-set", "1", 0);
 
-                var result = connection.GetSetContains("{hangfire}:some-set", "1");
+                var result = connection.GetSetContains("some-set", "1");
 
                 Assert.True(result);
             });
         }
+
         [Fact, CleanRedis]
         public void SetContains_ReturnFalseIfNotContained()
         {
@@ -223,11 +249,12 @@ namespace Hangfire.Redis.Tests
             {
                 redis.SortedSetAdd("{hangfire}:some-set", "1", 0);
 
-                var result = connection.GetSetContains("{hangfire}:some-set", "0");
+                var result = connection.GetSetContains("some-set", "0");
 
                 Assert.False(result);
             });
         }
+
         private void UseConnections(Action<IDatabase, RedisConnection> action)
         {
             var redis = RedisUtils.CreateClient();


### PR DESCRIPTION
This PR will fix the missing key prefixing (`{hangfire}:`) for `GetSetCount` and `GetSetContains`.

Solve #130 