### PR TITLE
Requeue dead jobs properly

### DIFF
--- a/Hangfire.Redis.StackExchange/RedisConnection.cs
+++ b/Hangfire.Redis.StackExchange/RedisConnection.cs
@@ -162,11 +162,6 @@ namespace Hangfire.Redis.StackExchange
                 storedParameters.Add("Queue", invocationData.Queue);
             }
 
-            if (invocationData.Queue != null)
-            {
-                storedParameters.Add("Queue", invocationData.Queue);
-            }
-
             if (_storage.UseTransactions)
             {
                 var transaction = Redis.CreateTransaction();

--- a/Hangfire.Redis.StackExchange/RedisStorage.cs
+++ b/Hangfire.Redis.StackExchange/RedisStorage.cs
@@ -1,4 +1,4 @@
-// Copyright ?2013-2015 Sergey Odinokov, Marco Casamento
+// Copyright © 2013-2015 Sergey Odinokov, Marco Casamento
 // This software is based on https://github.com/HangfireIO/Hangfire.Redis
 
 // Hangfire.Redis.StackExchange is free software: you can redistribute it and/or modify
@@ -45,40 +45,54 @@ namespace Hangfire.Redis.StackExchange
                 { JobStorageFeatures.Connection.GetSetContains, true }, 
                 { JobStorageFeatures.Connection.LimitedGetSetCount, true }, 
                 { JobStorageFeatures.Transaction.AcquireDistributedLock, true }, 
-                { JobStorageFeatures.Transaction.CreateJob, true }, 
-                { JobStorageFeatures.Transaction.SetJobParameter, true}, 
-                { JobStorageFeatures.Monitoring.DeletedStateGraphs, true }, 
+                { JobStorageFeatures.Transaction.CreateJob, true }, // overridden in constructor
+                { JobStorageFeatures.Transaction.SetJobParameter, true}, // overridden in constructor 
+                { JobStorageFeatures.Transaction.RemoveFromQueue(typeof(RedisFetchedJob)), true }, // overridden in constructor                { JobStorageFeatures.Monitoring.DeletedStateGraphs, true }, 
                 { JobStorageFeatures.Monitoring.AwaitingJobs, true }
             };
 
         public RedisStorage()
-            : this("localhost:6379")
+            : this("localhost:6379", null, null)
         {
         }
 
         public RedisStorage(IConnectionMultiplexer connectionMultiplexer, RedisStorageOptions options = null)
+            : this("UseConnectionMultiplexer", connectionMultiplexer, options)
         {
-            _options = options ?? new RedisStorageOptions();
-
-            _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
-            _redisOptions = ConfigurationOptions.Parse(_connectionMultiplexer.Configuration);
-            
-            _subscription = new RedisSubscription(this, _connectionMultiplexer.GetSubscriber());
         }
 
         public RedisStorage(string connectionString, RedisStorageOptions options = null)
+            : this(connectionString, null, options)
         {
-            if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+        }
 
-            _redisOptions = ConfigurationOptions.Parse(connectionString);
+        private RedisStorage(string connectionString, IConnectionMultiplexer connectionMultiplexer, 
+            RedisStorageOptions options = null)
+        {
+            if (connectionString == null)
+                throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString == "UseConnectionMultiplexer" && connectionMultiplexer == null)
+                throw new ArgumentNullException(nameof(connectionMultiplexer));
+
+            _connectionMultiplexer = connectionMultiplexer ?? ConnectionMultiplexer.Connect(connectionString);
+
+            _redisOptions = ConfigurationOptions.Parse(_connectionMultiplexer.Configuration);
 
             _options = options ?? new RedisStorageOptions
             {
                 Db = _redisOptions.DefaultDatabase ?? 0
             };
 
-            _connectionMultiplexer = ConnectionMultiplexer.Connect(connectionString);
+            SetTransactionalFeatures();
+
             _subscription = new RedisSubscription(this, _connectionMultiplexer.GetSubscriber());
+        }
+
+        private void SetTransactionalFeatures()
+        {
+            _features[JobStorageFeatures.Transaction.CreateJob] = _options.UseTransactions; 
+            _features[JobStorageFeatures.Transaction.SetJobParameter] = _options.UseTransactions; 
+            _features[JobStorageFeatures.Transaction.RemoveFromQueue(typeof(RedisFetchedJob))] = _options.UseTransactions; 
         }
 
         public string ConnectionString => _connectionMultiplexer.Configuration;

--- a/Hangfire.Redis.Tests/RedisFetchedJobFacts.cs
+++ b/Hangfire.Redis.Tests/RedisFetchedJobFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Hangfire.Common;
 using Hangfire.Redis.StackExchange;
 using Hangfire.Redis.Tests.Utils;
 using Moq;
@@ -28,28 +29,28 @@ namespace Hangfire.Redis.Tests
         public void Ctor_ThrowsAnException_WhenStorageIsNull()
         {
            Assert.Throws<ArgumentNullException>("storage",
-                () => new RedisFetchedJob(null, _redis.Object, JobId, Queue));
+               () => new RedisFetchedJob(null, _redis.Object, JobId, Queue, DateTime.UtcNow));
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenRedisIsNull()
         {
             Assert.Throws<ArgumentNullException>("redis",
-                () => new RedisFetchedJob(_storage, null, JobId, Queue));
+                () => new RedisFetchedJob(_storage, null, JobId, Queue, DateTime.UtcNow));
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenJobIdIsNull()
         {
             Assert.Throws<ArgumentNullException>("jobId",
-                () => new RedisFetchedJob(_storage, _redis.Object, null, Queue));
+                () => new RedisFetchedJob(_storage, _redis.Object, null, Queue, DateTime.UtcNow));
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenQueueIsNull()
         {
             Assert.Throws<ArgumentNullException>("queue",
-                () => new RedisFetchedJob(_storage, _redis.Object, JobId, null));
+                () => new RedisFetchedJob(_storage, _redis.Object, JobId, null, DateTime.UtcNow));
         }
 
         [Fact, CleanRedis]
@@ -59,8 +60,10 @@ namespace Hangfire.Redis.Tests
             {
                 // Arrange
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
-
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue");
+                
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:job-id", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.RemoveFromQueue();
@@ -79,7 +82,10 @@ namespace Hangfire.Redis.Tests
 				redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "another-job-id");
 
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:job-id", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+                redis.HashSet("{hangfire}:job:another-job-id", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.RemoveFromQueue();
@@ -91,6 +97,27 @@ namespace Hangfire.Redis.Tests
         }
 
         [Fact, CleanRedis]
+        public void RemoveFromQueue_DoesNotRemoveIfFetchedDoesntMatch()
+        {
+            UseRedis(redis =>
+            {
+                // Arrange
+				redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
+
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:job-id", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue", fetchedAt + TimeSpan.FromSeconds(1));
+
+                // Act
+                fetchedJob.RemoveFromQueue();
+
+                // Assert
+                Assert.Equal(1, redis.ListLength("{hangfire}:queue:my-queue:dequeued"));
+                Assert.Equal("job-id", (string)redis.ListRightPop("{hangfire}:queue:my-queue:dequeued"));
+            });
+        }
+
+        [Fact, CleanRedis]
         public void RemoveFromQueue_RemovesOnlyOneJob()
         {
             UseRedis(redis =>
@@ -98,8 +125,10 @@ namespace Hangfire.Redis.Tests
                 // Arrange
 				redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:job-id", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
 
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue");
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.RemoveFromQueue();
@@ -115,8 +144,9 @@ namespace Hangfire.Redis.Tests
             UseRedis(redis =>
             {
                 // Arrange
-                redis.HashSet("{hangfire}:job:my-job", "Fetched", "value");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:my-job", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.RemoveFromQueue();
@@ -132,8 +162,8 @@ namespace Hangfire.Redis.Tests
             UseRedis(redis =>
             {
                 // Arrange
-                redis.HashSet("{hangfire}:job:my-job", "Checked", "value");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                redis.HashSet("{hangfire}:job:my-job", "Checked", JobHelper.SerializeDateTime(DateTime.UtcNow));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", null);
 
                 // Act
                 fetchedJob.RemoveFromQueue();
@@ -150,13 +180,17 @@ namespace Hangfire.Redis.Tests
             {
                 // Arrange
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:my-job", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.Requeue();
 
                 // Assert
                 Assert.Equal("my-job", (string)redis.ListRightPop("{hangfire}:queue:my-queue"));
+                Assert.Null((string)redis.ListLeftPop("{hangfire}:queue:my-queue:dequeued"));
             });
         }
 
@@ -168,14 +202,18 @@ namespace Hangfire.Redis.Tests
                 // Arrange
 				redis.ListRightPush("{hangfire}:queue:my-queue", "another-job");
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:my-job", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
 
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.Requeue();
 
                 // Assert - RPOP
-                Assert.Equal("my-job", (string)redis.ListRightPop("{hangfire}:queue:my-queue")); 
+                Assert.Equal("my-job", (string)redis.ListRightPop("{hangfire}:queue:my-queue"));
+                Assert.Null((string)redis.ListRightPop("{hangfire}:queue:my-queue:dequeued"));
             });
         }
 
@@ -186,7 +224,10 @@ namespace Hangfire.Redis.Tests
             {
                 // Arrange
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:my-job", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.Requeue();
@@ -202,8 +243,9 @@ namespace Hangfire.Redis.Tests
             UseRedis(redis =>
             {
                 // Arrange
-                redis.HashSet("{hangfire}:job:my-job", "Fetched", "value");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                var fetchedAt = DateTime.UtcNow;
+                redis.HashSet("{hangfire}:job:my-job", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", fetchedAt);
 
                 // Act
                 fetchedJob.Requeue();
@@ -219,8 +261,8 @@ namespace Hangfire.Redis.Tests
             UseRedis(redis =>
             {
                 // Arrange
-                redis.HashSet("{hangfire}:job:my-job", "Checked", "value");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                redis.HashSet("{hangfire}:job:my-job", "Checked", JobHelper.SerializeDateTime(DateTime.UtcNow));
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", null);
 
                 // Act
                 fetchedJob.Requeue();
@@ -237,7 +279,7 @@ namespace Hangfire.Redis.Tests
             {
                 // Arrange
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", DateTime.UtcNow);
 
                 // Act
                 fetchedJob.Dispose();
@@ -255,7 +297,7 @@ namespace Hangfire.Redis.Tests
                 // Arrange
 				redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
                 redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "my-job");
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue");
+                var fetchedJob = new RedisFetchedJob(_storage, redis, "my-job", "my-queue", DateTime.UtcNow);
 
                 // Act
                 fetchedJob.RemoveFromQueue();

--- a/Hangfire.Redis.Tests/RedisFetchedJobFacts.cs
+++ b/Hangfire.Redis.Tests/RedisFetchedJobFacts.cs
@@ -118,27 +118,6 @@ namespace Hangfire.Redis.Tests
         }
 
         [Fact, CleanRedis]
-        public void RemoveFromQueue_RemovesOnlyOneJob()
-        {
-            UseRedis(redis =>
-            {
-                // Arrange
-				redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
-                redis.ListRightPush("{hangfire}:queue:my-queue:dequeued", "job-id");
-                var fetchedAt = DateTime.UtcNow;
-                redis.HashSet("{hangfire}:job:job-id", "Fetched", JobHelper.SerializeDateTime(fetchedAt));
-
-                var fetchedJob = new RedisFetchedJob(_storage, redis, "job-id", "my-queue", fetchedAt);
-
-                // Act
-                fetchedJob.RemoveFromQueue();
-
-                // Assert
-                Assert.Equal(1, redis.ListLength("{hangfire}:queue:my-queue:dequeued"));
-            });
-        }
-
-        [Fact, CleanRedis]
         public void RemoveFromQueue_RemovesTheFetchedFlag()
         {
             UseRedis(redis =>


### PR DESCRIPTION
Fixes #135 

This PR includes several changes:
1. When a `RedisFetchedJob` is created / fetched, it also records the `Fetched` time not only in its `Fetched` hash entry, but also as a property in its object. As such, when the job is requeued or removed from queue, its `Fetched` hash entry is only removed if the values match (i.e. if there was no other process that updated this value before the current process). The same logic applies to the `dequeued` list.
- The two concurrent processes trying to remove and requeue the jobs are `ServerJobCancellationWatcher` and `FetchedJobsWatcher`.

2. When `FetchedJobsWatcher` checks whether the job should be requeued, it also checks if this job is being executed on a live server (i.e. the server that has not been removed from the list of servers by `ServerWatchdog`). **Note** that it will not requeue the job that is being executed on a possibly aborted server that is still present in the list, judging by last heartbeat time. The reason is that server heartbeat and server timeout are values configurable **per server**, and the current `FetchedJobsWatcher` process has no insight into how these settings may be configured on other servers. Thus, it can't make decisions whether a particular server is aborted or not.

3. `RedisStorage` transactional feature flags are now reported to the core library depending on how the user configured them. If the user specified `UseTransactions = false`, the storage reports to the core library that it does not support transactions.

4. Deduplicated `RedisStorage` constructors. The way to determine what parameter is set is questionable.

5. When a `RedisFetchedJob` is requeued, it now publishes its id to the subscription channel for immediate execution.